### PR TITLE
feat: add description to press release index, remove unused template

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -29,15 +29,15 @@ indices:
       - '/news-and-stories/press-releases/'
     target: /press-releases.json
     properties:
-      template:
-        select: head > meta[name="template"]
-        value: attribute(el, "content")
       title:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
       image:
         select: head > meta[property="og:image"]
         value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      description:
+          select: head > meta[property="og:description"]
+          value: attribute(el, "content")
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://press-release-index-description--vg-volvotrucks-us--hlxsites.hlx.page/
