### PR TITLE
fix: display correct date string in press overview

### DIFF
--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -91,7 +91,7 @@ function buildPressReleaseArticle(entry) {
     ${pictureTag}
   </a>
   <div>
-    <span class="date">${date.toLocaleDateString()}</span>
+    <span class="date">${date.toLocaleDateString('en-US')}</span>
     <h3><a href="${path}">${title}</a></h3>
     <p>${description}</p>
   </div>`;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/press-releases/
- After: https://date-string-press-releases--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/press-releases/
