### PR TITLE
feat: related press releases

### DIFF
--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -107,7 +107,7 @@ function createPressReleaseList(pressReleases, limit, block) {
 }
 
 function createLatestPressReleases(mainEl, pressReleases) {
-  mainEl.innerHTML = '';
+  mainEl.innerText = '';
   buildHeader(mainEl);
   const articleCards = document.createElement('div');
   articleCards.classList.add('press-releases-cards');


### PR DESCRIPTION
- add capability to provide related press releases via block config

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #113

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/drafts/pauli/i-torque-press-releases
- After: https://113-related-press-releases--vg-volvotrucks-us--hlxsites.hlx.page/drafts/pauli/i-torque-press-releases
