### PR TITLE
fix: teaser cards gap

### DIFF
--- a/blocks/teaser-cards/teaser-cards.css
+++ b/blocks/teaser-cards/teaser-cards.css
@@ -18,8 +18,7 @@
 /* first row div */
 .block.teaser-cards > div {
   display: flex;
-  column-gap: 30px;
-  row-gap: 60px;
+  gap: 30px;
   flex-flow: column;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #147 

Please be aware that this is not a pixel perfect match for all the cases on the original site.

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://teaser-cards-gap--vg-volvotrucks-us--hlxsites.hlx.page/
