### PR TITLE
fix: subnav background moves after content loaded

### DIFF
--- a/blocks/sub-nav/sub-nav.css
+++ b/blocks/sub-nav/sub-nav.css
@@ -109,6 +109,7 @@
     .block.sub-nav li:first-child,
     .block.sub-nav li:first-child:not(.active) {
         padding: 0;
+        display: block;
     }
 
     .block.sub-nav li:first-child a {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -130,6 +130,7 @@ body.appear {
 }
 
 header {
+  position: relative;
   min-height: var(--nav-height);
 }
 
@@ -147,6 +148,10 @@ header .sub-nav.block {
   height: var(--sub-nav-height);
   background-color: #7F7F7F;
   z-index: 1020;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  position: absolute;
 }
 
 h1, h2, h3,
@@ -478,8 +483,7 @@ a.button.text-link-with-video::after {
   header .sub-nav.block {
     position: fixed;
     top: var(--nav-height);
-    left: 0;
-    right: 0;
+    bottom: unset;
   }
 }
 


### PR DESCRIPTION
With throttling enabled to slow 3g the dark sub navigation background is positioned on top of the header and shifting down after the navigation content loaded. With this change the sub navigation is fixed to the bottom of the header always.

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr-electric/
- After: https://fix-sub-nav-background-shift--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr-electric/
