### PR TITLE
fix: initialise carousel after section loaded

### DIFF
--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -34,7 +34,14 @@ function adjustWidthAndControls(block, carousel, ...controls) {
     resizeTimeout = setTimeout(toggle, debounceDelay);
   });
 
-  window.setTimeout(toggle);
+  // wait for the section to be loaded before we initially resize the carousel
+  const section = block.closest('.section');
+  new MutationObserver((mutations, observer) => mutations.forEach((mutation) => {
+    if (section.dataset.sectionStatus === 'loaded') {
+      observer.disconnect();
+      setTimeout(toggle);
+    }
+  })).observe(section, { attributes: true });
 }
 
 function createDesktopControls(ul) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -36,12 +36,12 @@ function adjustWidthAndControls(block, carousel, ...controls) {
 
   // wait for the section to be loaded before we initially resize the carousel
   const section = block.closest('.section');
-  new MutationObserver((mutations, observer) => mutations.forEach((mutation) => {
+  new MutationObserver((_, observer) => {
     if (section.dataset.sectionStatus === 'loaded') {
       observer.disconnect();
       setTimeout(toggle);
     }
-  })).observe(section, { attributes: true });
+  }).observe(section, { attributes: true });
 }
 
 function createDesktopControls(ul) {


### PR DESCRIPTION
The carousel does not properly initialise when it shares a section with other blocks loaded asynchronously as the item and container width default to `auto` until the section is actually loaded / show. 

<img width="1933" alt="Screenshot 2023-03-29 at 11 59 04" src="https://user-images.githubusercontent.com/558094/228498956-5f43bf5e-e54d-4695-b9df-15abbf8273d4.png">

Instead of using a timeout I used now a mutation observer that triggers the toggle once the section is set to loaded.

<img width="1287" alt="Screenshot 2023-03-29 at 11 59 25" src="https://user-images.githubusercontent.com/558094/228499031-a1bb2362-70f4-4bfc-9ffe-9f0762ebe644.png">


Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/drafts/drudolph/vnr/
- After: https://fix-carousel-init--vg-volvotrucks-us--hlxsites.hlx.page/drafts/drudolph/vnr/
