### PR TITLE
feat: added helix-sitemap.yaml

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,5 +1,5 @@
- sitemaps:
-   allindex:
-     origin: https://www.volvotrucks.us
-     source: /query-index.json
-     destination: /sitemap.xml
+sitemaps:
+  allindex:
+    origin: https://www.volvotrucks.us
+    source: /query-index.json
+    destination: /sitemap.xml

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,0 +1,5 @@
+ sitemaps:
+   allindex:
+     origin: https://www.volvotrucks.us
+     source: /query-index.json
+     destination: /sitemap.xml


### PR DESCRIPTION
Add a helix-sitemap.yaml, to generate a sitemap at /sitemap.xml. I think this needs to be merged into main before the sitemap starts populating.

Fix #16

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://issue-16--vg-volvotrucks-us--hlxsites.hlx.page/
