### PR TITLE
fix: add missing space above trailing line

### DIFF
--- a/blocks/key-facts/key-facts.css
+++ b/blocks/key-facts/key-facts.css
@@ -69,7 +69,11 @@
 
 /* the trailing line */
 .key-facts-wrapper .key-facts .key-fact > div {
-  width: 100%;;
+  width: 100%;
+}
+
+.key-fact div.trailing-line {
+  margin-top: 48px; 
 }
 
 .key-fact div.trailing-line::before {


### PR DESCRIPTION
Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnx/performance/
- After: https://fix-space-before-trailingline--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnx/performance/
