### PR TITLE
feat: spec table header without images for multiple columns

### DIFF
--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -87,8 +87,8 @@ export default async function decorate(block) {
     mobileColumnHeader.className = 'column-header-mobile';
     mobileColumnHeader.innerHTML = `<select>
       ${[...header.querySelectorAll('[role="columnheader"]')]
-        .map((columnHeader, i) => `<option value="${i + 1}">${columnHeader.textContent}</option>`)
-        .join('')}
+    .map((columnHeader, i) => `<option value="${i + 1}">${columnHeader.textContent}</option>`)
+    .join('')}
       </select>`;
     mobileColumnHeader.firstElementChild.addEventListener('change', changeMobileColumn);
     header.insertAdjacentElement('afterend', mobileColumnHeader);

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -24,12 +24,17 @@ function expand(event) {
 
 function normalizeCells(cells, rowheaderRole = 'rowheader', cellRole = 'cell') {
   [...cells].forEach((cell, j) => {
+    cell.normalize();
+    // remove any blank text nodes
+    if (cell.firstChild && cell.firstChild.nodeType === 3 && cell.firstChild.nodeValue.trim() === '') cell.firstChild.remove();
+    if (cell.lastChild && cell.lastChild.nodeType === 3 && cell.lastChild.nodeValue.trim() === '') cell.lastChild.remove();
+    // remove leading or trailing breaks
+    if (cell.firstChild && cell.firstChild.tagName === 'BR') cell.firstChild.remove();
+    if (cell.lastChild && cell.lastChild.tagName === 'BR') cell.lastChild.remove();
     // wrap text-only cells with a <p>
     if (!cell.children.length && cell.textContent !== '') {
       cell.innerHTML = `<p>${cell.textContent}</p>`;
     }
-    if (cell.firstChild && cell.firstChild.tagName === 'BR') cell.firstChild.remove();
-    if (cell.lastChild && cell.lastChild.tagName === 'BR') cell.lastChild.remove();
     if (j === 0 && cells.length > 1) cell.role = rowheaderRole;
     else cell.role = cellRole;
     cell.className = 'cell';
@@ -57,35 +62,37 @@ export default async function decorate(block) {
   const colCount = block.firstElementChild.children.length;
   block.style.setProperty('--grid-col-count', colCount);
   const header = block.firstElementChild;
-  const pictures = header.querySelectorAll('picture');
   let firstRowIndex = 0;
 
-  // table header with images
-  if (pictures.length) {
-    const row = document.createElement('div');
-    row.className = 'image-header';
-    pictures.forEach((picture) => {
-      const cell = document.createElement('div');
-      cell.className = 'cell';
-      cell.appendChild(picture);
-      row.appendChild(cell);
-    });
-    header.insertAdjacentElement('beforebegin', row);
-    normalizeCells(row.children, 'cell');
+  // create a table header only if there are multiple columns in the first row
+  if (header.children.length > 1) {
+    const pictures = header.querySelectorAll('picture');
+    if (pictures.length > 0) {
+      const row = document.createElement('div');
+      row.className = 'image-header';
+      pictures.forEach((picture) => {
+        const cell = document.createElement('div');
+        cell.className = 'cell';
+        cell.appendChild(picture);
+        row.appendChild(cell);
+      });
+      header.insertAdjacentElement('beforebegin', row);
+      normalizeCells(row.children, 'cell');
+      firstRowIndex += 1;
+    }
 
-    // column header and mobile column header
     header.className = 'column-header';
     normalizeCells(header.children, 'rowheader', 'columnheader');
     const mobileColumnHeader = document.createElement('div');
     mobileColumnHeader.className = 'column-header-mobile';
     mobileColumnHeader.innerHTML = `<select>
       ${[...header.querySelectorAll('[role="columnheader"]')]
-    .map((columnHeader, i) => `<option value="${i + 1}">${columnHeader.textContent}</option>`)
-    .join('')}
+        .map((columnHeader, i) => `<option value="${i + 1}">${columnHeader.textContent}</option>`)
+        .join('')}
       </select>`;
     mobileColumnHeader.firstElementChild.addEventListener('change', changeMobileColumn);
     header.insertAdjacentElement('afterend', mobileColumnHeader);
-    firstRowIndex = 3;
+    firstRowIndex += 2;
   }
 
   // rowgroups and rows


### PR DESCRIPTION
From the import sheet https://www.volvotrucks.us/parts-and-services/services/uptime-service-solutions/diagnostic-tools/

Test URLs:

- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/parts-and-services/services/uptime-service-solutions/diagnostic-tools/
- After: https://spec-table-head-wo-img--vg-volvotrucks-us--hlxsites.hlx.page/parts-and-services/services/uptime-service-solutions/diagnostic-tools/

Should still work for:

- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr/specifications/
- After: https://spec-table-head-wo-img--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr/specifications/
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr/features/
- After: https://spec-table-head-wo-img--vg-volvotrucks-us--hlxsites.hlx.page/trucks/vnr/features/