### PR TITLE
#160 specification block used to be the faq block

### DIFF
--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -81,7 +81,7 @@
 .block.specifications .rowgroup-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;        
+    align-items: center;
     grid-column: span var(--grid-col-count);
     background: none;
     border-radius: 0;
@@ -92,7 +92,7 @@
     color: unset;
     text-align: unset;
     font-size: 16px;
-    width: 100%; 
+    width: 100%;
 }
 
 .block.specifications .rowgroup-header:hover {
@@ -103,6 +103,10 @@
     display: block;
     content: '\f067';
     font-family: var(--ff-fontawesome);
+}
+
+.block.specifications .rowgroup-header[aria-expanded="true"]::after {
+    content: '\f068';
 }
 
 /* column header mobile */

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -100,10 +100,11 @@ export default async function decorate(block) {
   for (let i = firstRowIndex, rowgroup = null; i < rows.length; i += 1) {
     const row = rows[i];
     const cells = row.children;
+    const firstChild = cells[0].firstElementChild;
 
     if (cells.length === 1
       && (!singleColumn
-        || (cells[0].children.length === 1 && cells[0].firstElementChild && cells[0].firstElementChild.tagName === 'STRONG'))) {
+        || (cells[0].children.length === 1 && firstChild && firstChild.tagName === 'STRONG'))) {
       const button = document.createElement('button');
       button.className = 'rowgroup-header';
       button.type = 'button';


### PR DESCRIPTION
instead of having multiple styles, it can be used the same style across all faq content.
in the following folder: "/parts-and-services/services/faqs/" is plain content, so instead of this I used a draft one "/drafts/jlledo/faqs-demo" that should fit all cases.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/drafts/jlledo/faqs-demo
- After: https://160-block-faq-accordion--vg-volvotrucks-us--hlxsites.hlx.page/drafts/jlledo/faqs-demo
