### PR TITLE
feat: featured press releases

### DIFF
--- a/blocks/press-releases/press-releases.css
+++ b/blocks/press-releases/press-releases.css
@@ -1,8 +1,3 @@
-.block.press-releases .press-releases-cards {
-    margin-top: 2.18em;
-    margin-bottom: 2.18em;
-}
-
 .block.press-releases article img {
     display: block;
     width: 100%;
@@ -20,14 +15,6 @@
 .block.press-releases article span.date {
     line-height: 2.1rem;
     font-size: 1.4rem;
-    color: var(--volvo-text-light-gray);
-}
-
-.block.press-releases .press-releases-cards span.date {
-    line-height: 1.4rem;
-    font-size: 1.6rem;
-    margin-top: 16px;
-    margin-bottom: 8px;
     color: var(--volvo-text-light-gray);
 }
 
@@ -163,6 +150,19 @@
     border-top: 1px solid var(--background-light-gray);
 }
 
+.block.press-releases.cards {
+    margin-top: 2.18em;
+    margin-bottom: 2.18em;
+}
+
+.block.press-releases.cards span.date {
+    line-height: 1.4rem;
+    font-size: 1.6rem;
+    margin-top: 16px;
+    margin-bottom: 8px;
+    color: var(--volvo-text-light-gray);
+}
+
 @media screen and (min-width: 768px){
     .block.press-releases .list-filter fieldset {
         display: flex;
@@ -179,19 +179,25 @@
         padding-right: 8px;
     }
 
-    .block.press-releases .press-releases-cards {
+    .block.press-releases .article-list article {
+        display: grid;
+        grid-template-columns: 25% calc(75% - 30px);
+        gap: 30px;
+    }
+
+    .block.press-releases.cards .article-list {
         display: flex;
         column-gap: 30px;
     }
 
-    .block.press-releases .press-releases-cards article {
+    .block.press-releases.cards .article-list li {
         flex: 0 1 33.3334%;
     }
 
-    .block.press-releases .article-list article {
-        display: grid;
-        grid-template-columns: 25% 75%;
-        gap: 30px;
+    .block.press-releases.cards .article-list article {
+        display: block;
+        padding: 0;
+        border-top: 0;
     }
 }
 

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -73,24 +73,23 @@ function buildPressReleaseArticle(entry) {
   return card;
 }
 
-function createFeaturedPressReleaseList(block, pressReleases) {
-  pressReleases.forEach((n) => {
-    n.filterTag = splitTags(n.tags);
-  });
-  // eslint-disable-next-line max-len
-  createList(pressReleases, undefined, undefined, buildPressReleaseArticle, undefined, block);
+function createPressReleaseList(block, pressReleases, {
+  filter = filterPressReleases,
+  filterFactory = createFilter,
+  articleFactory = buildPressReleaseArticle,
+  limit,
+}) {
+  // eslint-disable-next-line no-param-reassign
+  pressReleases = pressReleases.map((pr) => ({ ...pr, filterTag: splitTags(pr.tags) }));
+  createList(pressReleases, filter, filterFactory, articleFactory, limit, block);
 }
 
-function createPressReleaseList(block, pressReleases, limit) {
-  pressReleases.forEach((n) => {
-    n.filterTag = splitTags(n.tags);
-  });
-  // eslint-disable-next-line max-len
-  createList(pressReleases, filterPressReleases, createFilter, buildPressReleaseArticle, limit, block);
+function createFeaturedPressReleaseList(block, pressReleases) {
+  createPressReleaseList(block, pressReleases, { filter: null, filterFactory: null });
 }
 
 function createLatestPressReleases(block, pressReleases) {
-  createList(pressReleases, filterPressReleases, undefined, buildPressReleaseArticle, undefined, block);
+  createPressReleaseList(block, pressReleases, { filterFactory: null });
 }
 
 export default async function decorate(block) {

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -89,15 +89,8 @@ function createPressReleaseList(block, pressReleases, limit) {
   createList(pressReleases, filterPressReleases, createFilter, buildPressReleaseArticle, limit, block);
 }
 
-function createLatestPressReleases(mainEl, pressReleases) {
-  mainEl.innerText = '';
-  const articleCards = document.createElement('div');
-  articleCards.classList.add('press-releases-cards');
-  mainEl.appendChild(articleCards);
-  pressReleases.forEach((pressRelease) => {
-    const pressReleaseCard = buildPressReleaseArticle(pressRelease);
-    articleCards.appendChild(pressReleaseCard);
-  });
+function createLatestPressReleases(block, pressReleases) {
+  createList(pressReleases, filterPressReleases, undefined, buildPressReleaseArticle, undefined, block);
 }
 
 export default async function decorate(block) {

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -106,9 +106,12 @@ export default async function decorate(block) {
 
   if (isFeatured) {
     const links = [...block.firstElementChild.querySelectorAll('a')]
-      .map(({ href }) => href ? new URL(href).pathname : null)
+      .map(({ href }) => (href ? new URL(href).pathname : null))
       .filter((pathname) => !!pathname);
-    const pressReleases = await getPressReleases(links.length, ({ path }) => links.indexOf(path) >= 0);
+    const pressReleases = await getPressReleases(
+      links.length,
+      ({ path }) => links.indexOf(path) >= 0,
+    );
     createFeaturedPressReleaseList(block, pressReleases);
   } else if (isLatest) {
     const pressReleases = await getPressReleases(3);

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -73,7 +73,15 @@ function buildPressReleaseArticle(entry) {
   return card;
 }
 
-function createPressReleaseList(pressReleases, limit, block) {
+function createFeaturedPressReleaseList(block, pressReleases) {
+  pressReleases.forEach((n) => {
+    n.filterTag = splitTags(n.tags);
+  });
+  // eslint-disable-next-line max-len
+  createList(pressReleases, undefined, undefined, buildPressReleaseArticle, undefined, block);
+}
+
+function createPressReleaseList(block, pressReleases, limit) {
   pressReleases.forEach((n) => {
     n.filterTag = splitTags(n.tags);
   });
@@ -101,12 +109,12 @@ export default async function decorate(block) {
       .map(({ href }) => href ? new URL(href).pathname : null)
       .filter((pathname) => !!pathname);
     const pressReleases = await getPressReleases(links.length, ({ path }) => links.indexOf(path) >= 0);
-    createLatestPressReleases(block, pressReleases);
+    createFeaturedPressReleaseList(block, pressReleases);
   } else if (isLatest) {
     const pressReleases = await getPressReleases(3);
     createLatestPressReleases(block, pressReleases);
   } else {
     const pressReleases = await getPressReleases();
-    createPressReleaseList(pressReleases, 10, block);
+    createPressReleaseList(block, pressReleases, 10);
   }
 }

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -29,6 +29,7 @@ indices:
       - '/news-and-stories/press-releases/**'
     exclude:
       - '/news-and-stories/press-releases/'
+      - '/news-and-stories/press-releases/sub-nav'
     target: /press-releases.json
     properties:
       title:

--- a/scripts/lib-ffetch.js
+++ b/scripts/lib-ffetch.js
@@ -346,22 +346,26 @@ export function createList(pressReleases, filter, createFilters, buildPressRelea
     };
     relatedPressReleases = true;
   }
-  const filteredData = filter(pressReleases, actFilter);
+  let filteredData = filter ? filter(pressReleases, actFilter) : pressReleases;
 
   let page = parseInt(getSelectionFromUrl('page'), 10);
   page = Number.isNaN(page) ? 1 : page;
-  const start = (page - 1) * limitPerPage;
   let pagination;
-  if (!relatedPressReleases) {
+  if (!relatedPressReleases && createFilters) {
     const filterElements = renderFilters(pressReleases, createFilters);
     mainEl.appendChild(filterElements);
-    pagination = createPagination(filteredData, page, limitPerPage);
-    mainEl.appendChild(pagination);
+    if (limitPerPage > 0) {
+      pagination = createPagination(filteredData, page, limitPerPage);
+      mainEl.appendChild(pagination);
+    }
   }
-  const dataToDisplay = filteredData.slice(start, start + limitPerPage);
+  if (limitPerPage > 0) {
+    const start = (page - 1) * limitPerPage;
+    filteredData = filteredData.slice(start, start + limitPerPage);
+  }
   const articleList = document.createElement('ul');
   articleList.className = 'article-list';
-  dataToDisplay.forEach((pressRelease) => {
+  filteredData.forEach((pressRelease) => {
     const articleItem = document.createElement('li');
     const pressReleaseArticle = buildPressReleaseArticle(pressRelease);
     articleItem.appendChild(pressReleaseArticle);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #258
Fix #290

This adds support for:
- latest (3) press releases, optionally by tag
- either as list (default) or as cards (when added to the class list)
- featured list of press releases

Featured Press Releases:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/powertrain/i-torque/
- After: https://featured-press-releases--vg-volvotrucks-us--hlxsites.hlx.page/trucks/powertrain/i-torque/

Latest Press Releases:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/
- After: https://featured-press-releases--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/

Press Releases:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.live/news-and-stories/press-releases/
- After: https://featured-press-releases--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/press-releases/
