### PR TITLE
fix: teaser cards with videos

### DIFF
--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -32,8 +32,8 @@ function normalizeCells(cells, rowheaderRole = 'rowheader', cellRole = 'cell') {
     if (cell.firstChild && cell.firstChild.tagName === 'BR') cell.firstChild.remove();
     if (cell.lastChild && cell.lastChild.tagName === 'BR') cell.lastChild.remove();
     // wrap text-only cells with a <p>
-    if (!cell.children.length && cell.textContent !== '') {
-      cell.innerHTML = `<p>${cell.textContent}</p>`;
+    if (!cell.querySelector('p') && cell.textContent !== '') {
+      cell.innerHTML = `<p>${cell.innerHTML}</p>`;
     }
     if (j === 0 && cells.length > 1) cell.role = rowheaderRole;
     else cell.role = cellRole;

--- a/blocks/teaser-cards/teaser-cards.js
+++ b/blocks/teaser-cards/teaser-cards.js
@@ -13,24 +13,25 @@ export default function decorate(block) {
     // give p containing the image a specific class
     const picture = elem.querySelector('picture');
     if (picture) picture.closest('p').classList.add('image');
-    // give all the other p a text class
-    elem.querySelector('p:not(.image, .button-container)')?.classList.add('text');
 
     const links = elem.querySelectorAll('a');
     const videos = [...links].filter((link) => isVideoLink(link));
 
     if (videos.length) {
       // display image as link with play icon
-      const image = elem.querySelector('.image');
       const selectedLink = selectVideoLink(videos);
 
       if (selectedLink) {
-        wrapImageWithVideoLink(selectedLink, image);
+        picture.after(selectedLink);
+        wrapImageWithVideoLink(selectedLink, picture);
       }
 
       // removing all of the videos links excluding the selected one
       videos.forEach((link) => link !== selectedLink && link.parentElement.remove());
     }
+
+    // give all the remainig p a text class
+    elem.querySelector('p:not(.image, .button-container)')?.classList.add('text');
 
     // give cta's link(s) a specific class name
     const ctaLinks = elem.querySelectorAll('.button-container a.button');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -453,7 +453,7 @@ export function wrapImageWithVideoLink(videoLink, image) {
   videoLink.innerText = '';
   videoLink.appendChild(image);
   videoLink.classList.add('link-with-video');
-  videoLink.classList.remove('button', 'primary');
+  videoLink.classList.remove('button', 'primary', 'text-link-with-video');
 
   addPlayIcon(videoLink);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -469,6 +469,9 @@ main .section.tabbed-container ul.tab-navigation li:hover {
   transform: translateX(-50%) translateY(-50%);
   z-index: 1;
   line-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .video-icon-wrapper:hover {


### PR DESCRIPTION
This moves the link into the the image `<p>` instead of moving the image into another `<p>`, which in the later iteration is removed (considering the links are separated by a `<br>`)

It also center-aligns the play button on hover.

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/meet-your-volvo/
- After: https://fix-teaser-cards-video--vg-volvotrucks-us--hlxsites.hlx.page/trucks/meet-your-volvo/
