### PR TITLE
Open links to https://build.volvotrucks.us/ in new tab

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,4 +1,5 @@
 import { readBlockConfig, decorateIcons } from '../../scripts/lib-franklin.js';
+import { decorateLinks } from '../../scripts/scripts.js';
 
 // media query match that indicates mobile/desktop switch
 const MQ = window.matchMedia('(min-width: 992px)');
@@ -115,6 +116,7 @@ function buildSectionMenuContent(sectionMenu, navCta, menuBlock) {
   }
 
   content.append(overviewLi, ...subSectionMenus);
+  decorateLinks(content);
   sectionMenu.append(content);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -286,8 +286,8 @@ function decorateHyperlinkImages(container) {
     });
 }
 
-function decorateLinks(main) {
-  [...main.querySelectorAll('a')]
+export function decorateLinks(block) {
+  [...block.querySelectorAll('a')]
     .filter(({ href }) => !!href)
     .forEach((link) => {
       /* eslint-disable no-use-before-define */
@@ -301,7 +301,7 @@ function decorateLinks(main) {
 
       const url = new URL(link.href);
       const external = !url.host.match('volvotrucks.(us|ca)') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
-      if (url.pathname.endsWith('.pdf') || external) {
+      if (url.host.match('build.volvotrucks.(us|ca)') || url.pathname.endsWith('.pdf') || external) {
         link.target = '_blank';
       }
     });


### PR DESCRIPTION
Test: the link is in the nav: trucks: `Build Your VNL`

Fix #14

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://14-open-build-in-new-tab--vg-volvotrucks-us--hlxsites.hlx.page/
