### PR TITLE
fix: add load time filtering for pr block with tags

### DIFF
--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -22,7 +22,7 @@ function createPressReleaseFilterFunction(activeFilters) {
       if (!terms.every((term) => !stopWords.includes(term) && text.includes(term))) return false;
     }
     return true;
-  }
+  };
 }
 
 function filterPressReleases(pressReleases, activeFilters) {

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -6,25 +6,27 @@ import {
 import {
   toClassName,
   createOptimizedPicture,
+  readBlockConfig,
 } from '../../scripts/lib-franklin.js';
 
-function filterPressReleases(pressReleases, activeFilters) {
-  let filteredPressReleases = pressReleases;
-  if (activeFilters.tags) {
-    filteredPressReleases = filteredPressReleases
-      .filter((n) => toClassName(n.tags).includes(activeFilters.tags));
-  }
+const stopWords = ['a', 'an', 'the', 'and', 'to', 'for', 'i', 'of', 'on', 'into'];
 
-  if (activeFilters.search) {
-    const terms = activeFilters.search.toLowerCase().split(' ').map((e) => e.trim()).filter((e) => !!e);
-    const stopWords = ['a', 'an', 'the', 'and', 'to', 'for', 'i', 'of', 'on', 'into'];
-    filteredPressReleases = filteredPressReleases
-      .filter((n) => {
-        const text = n.content.toLowerCase();
-        return terms.every((term) => !stopWords.includes(term) && text.includes(term));
-      });
+function createPressReleaseFilterFunction(activeFilters) {
+  return (pr) => {
+    if (activeFilters.tags) {
+      if (!toClassName(pr.tags).includes(activeFilters.tags)) return false;
+    }
+    if (activeFilters.search) {
+      const terms = activeFilters.search.toLowerCase().split(' ').map((e) => e.trim()).filter((e) => !!e);
+      const text = pr.content.toLowerCase();
+      if (!terms.every((term) => !stopWords.includes(term) && text.includes(term))) return false;
+    }
+    return true;
   }
-  return filteredPressReleases;
+}
+
+function filterPressReleases(pressReleases, activeFilters) {
+  return pressReleases.filter(createPressReleaseFilterFunction(activeFilters));
 }
 
 function createFilter(pressReleases, activeFilters, createDropdown, createFullText) {
@@ -41,9 +43,9 @@ function createFilter(pressReleases, activeFilters, createDropdown, createFullTe
   ];
 }
 
-async function getPressReleases(limit, filter) {
+function getPressReleases(limit, filter) {
   const indexUrl = new URL('/press-releases.json', window.location.origin);
-  let pressReleases = ffetch(indexUrl).chunks(500);
+  let pressReleases = ffetch(indexUrl);
   if (filter) pressReleases = pressReleases.filter(filter);
   if (limit) pressReleases = pressReleases.limit(limit);
   return pressReleases.all();
@@ -104,8 +106,13 @@ export default async function decorate(block) {
       ({ path }) => links.indexOf(path) >= 0,
     );
     createFeaturedPressReleaseList(block, pressReleases);
-  } else if (isLatest) {
-    const pressReleases = await getPressReleases(3);
+    return;
+  }
+
+  if (isLatest) {
+    const cfg = readBlockConfig(block);
+    const filter = cfg.tags && createPressReleaseFilterFunction({ tags: toClassName(cfg.tags) });
+    const pressReleases = await getPressReleases(3, filter);
     createLatestPressReleases(block, pressReleases);
   } else {
     const pressReleases = await getPressReleases();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #258

The limit applied in the press-releases.js returned only the first 3 press releases without taking the active filters into account.   Now the limit is applied with a filter already at load time.

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/powertrain/i-torque/
- After: https://latestpr-w-filter--vg-volvotrucks-us--hlxsites.hlx.page/trucks/powertrain/i-torque/
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/
- After: https://latestpr-w-filter--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/
