### PR TITLE
fix #337: use link href and ignore link text if they differ. Link the image instead of printing a standalone link. 

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -240,15 +240,8 @@ function decorateSectionBackgrounds(main) {
 function decorateHyperlinkImages(container) {
   // picture + br + a in the same paragraph
   [...container.querySelectorAll('picture + br + a')]
-    // link text is an unformatted URL paste, and matches the link href
-    .filter((a) => {
-      try {
-        // ignore domain in comparison
-        return new URL(a.href).pathname === new URL(a.textContent).pathname;
-      } catch (e) {
-        return false;
-      }
-    })
+    // link text is an unformatted URL paste
+    .filter((a) => a.textContent.trim().startsWith('http'))
     .forEach((a) => {
       const picture = a.previousElementSibling.previousElementSibling;
       picture.remove();


### PR DESCRIPTION
Fix #337

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/drafts/wingeier/wrong-link
- After: https://337-images-not-linked--vg-volvotrucks-us--hlxsites.hlx.page/drafts/wingeier/wrong-link

<img width="1337" alt="Screenshot 2023-04-19 at 10 12 02" src="https://user-images.githubusercontent.com/2250964/233150009-0b1c4512-2584-412f-9e2f-3e2d66ac7a1b.png">

