### PR TITLE
add press date

### DIFF
--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -1,0 +1,4 @@
+.prdate {
+    font-size: var(--body-font-size-s);
+    margin-top: -15px;
+}

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -1,0 +1,15 @@
+function addPressReleaseDate(main, doc) {
+  const prHead = main.querySelector('div > div > h1');
+  const prDate = doc.querySelector('meta[name="publish-date"]');
+  // this should only fire on press-release pages
+  if (window.location.href.indexOf('/news-and-stories/press-releases/') !== -1 && prHead && prDate) {
+    const dateDiv = document.createElement('div');
+    dateDiv.classList.add('prdate');
+    dateDiv.innerHTML = prDate.content;
+    prHead.insertAdjacentElement('afterend', dateDiv);
+  }
+}
+
+export default async function decorate(doc) {
+  addPressReleaseDate(doc.querySelector('main'), doc);
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #358 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/
- After: https://358-pd-missing-on-prs--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/
