### PR TITLE
set target for jpeg to _blank

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -287,7 +287,7 @@ export function decorateLinks(block) {
 
       const url = new URL(link.href);
       const external = !url.host.match('volvotrucks.(us|ca)') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
-      if (url.host.match('build.volvotrucks.(us|ca)') || url.pathname.endsWith('.pdf') || external) {
+      if (url.host.match('build.volvotrucks.(us|ca)') || url.pathname.endsWith('.pdf') || url.pathname.endsWith('.jpeg') || external) {
         link.target = '_blank';
       }
     });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #364

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/trucks/calendar/
- After: https://364-image-download--vg-volvotrucks-us--hlxsites.hlx.page/trucks/calendar/
- Reference site: https://us.vtnaprod-cm.na.volvogroup.com/trucks/calendar/

Created the page with thumbnails that link to high res images.
Clicking on the image or the month link will download the high res image.

Did not add the download icon overlay.