### PR TITLE
#392 subscribe button jump to the form

### DIFF
--- a/blocks/eloqua-form/eloqua-form.js
+++ b/blocks/eloqua-form/eloqua-form.js
@@ -98,13 +98,16 @@ const addForm = async (block) => {
 };
 
 export default async function decorate(block) {
+  const isMagazineTemplate = document.querySelector('meta[content="magazine"]');
   const observer = new IntersectionObserver((entries) => {
     if (entries.some((e) => e.isIntersecting)) {
       observer.disconnect();
+      if (isMagazineTemplate) block.removeAttribute('id');
       addForm(block);
     }
   }, {
     rootMargin: '300px',
   });
   observer.observe(block);
+  if (isMagazineTemplate) block.id = 'form59';
 }

--- a/templates/magazine/magazine.js
+++ b/templates/magazine/magazine.js
@@ -111,7 +111,7 @@ export default async function decorate(doc) {
   // subscribe
   const subscribeSidebar = createElement('div', 'subscribe');
   const button = createElement('a', 'cta');
-  button.href = '#eloquaForm';
+  button.href = '#form59';
   button.innerText = 'Subscribe';
   const arrowIcon = createElement('span', ['icon', 'icon-fa-angle-right']);
   button.append(arrowIcon);


### PR DESCRIPTION
eloqua forms load with an intersection observer, which means that only loads if there are present in the viewport, so is needed to add a temporal id attribute to its block father element to enable the anchor navigation to do the trick

Fix #392 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/volvo-trucks-magazine/cover-story/
- After: https://392-subscribe-button-not-working--vg-volvotrucks-us--hlxsites.hlx.page/news-and-stories/volvo-trucks-magazine/cover-story/
