### PR TITLE
417 search connector add tags

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -157,7 +157,4 @@ indices:
         value: attribute(el, "content")
       tags:
         select: head > meta[property="article:tag"]
-        values: attribute(el, "content")            
-      category:
-        select: head > meta[property="category"]
-        value: attribute(el, "content")      
+        values: attribute(el, "content")   

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -152,4 +152,12 @@ indices:
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
-      
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      tags:
+        select: head > meta[property="article:tag"]
+        values: attribute(el, "content")            
+      category:
+        select: head > meta[property="category"]
+        value: attribute(el, "content")      


### PR DESCRIPTION
Update helix-search search index to handle tags and categories

Fix #417 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://417-search-connector-add-tags--vg-volvotrucks-us--hlxsites.hlx.page/
