### PR TITLE
fix: migration to new sidekick library

### DIFF
--- a/blocks/body-builder-news/body-builder-news.js
+++ b/blocks/body-builder-news/body-builder-news.js
@@ -1,8 +1,8 @@
-import { createOptimizedPicture, readBlockConfig } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, getOrigin, readBlockConfig } from '../../scripts/lib-franklin.js';
 import { ffetch } from '../../scripts/lib-ffetch.js';
 
 async function getArticles(path, limit) {
-  const indexUrl = new URL(path, window.location.origin);
+  const indexUrl = new URL(path, getOrigin());
   return ffetch(indexUrl).sheet('sorted').limit(limit).all();
 }
 

--- a/blocks/magazine-articles/magazine-articles.js
+++ b/blocks/magazine-articles/magazine-articles.js
@@ -5,6 +5,7 @@ import {
 } from '../../scripts/lib-ffetch.js';
 import {
   createOptimizedPicture,
+  getOrigin,
   toClassName,
 } from '../../scripts/lib-franklin.js';
 
@@ -146,7 +147,7 @@ async function createLatestMagazineArticles(mainEl, magazineArticles) {
 }
 
 async function getMagazineArticles(limit) {
-  const indexUrl = new URL('/magazine-articles.json', window.location.origin);
+  const indexUrl = new URL('/magazine-articles.json', getOrigin());
   let articles;
   if (limit) {
     articles = ffetch(indexUrl).limit(limit).all();

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -7,8 +7,8 @@ import {
   toClassName,
   createOptimizedPicture,
   readBlockConfig,
+  getOrigin,
 } from '../../scripts/lib-franklin.js';
-import { getOrigin } from '../../scripts/lib-franklin.js';
 
 const stopWords = ['a', 'an', 'the', 'and', 'to', 'for', 'i', 'of', 'on', 'into'];
 
@@ -45,7 +45,6 @@ function createFilter(pressReleases, activeFilters, createDropdown, createFullTe
 }
 
 function getPressReleases(limit, filter) {
-  
   const indexUrl = new URL('/press-releases.json', getOrigin());
   let pressReleases = ffetch(indexUrl);
   if (filter) pressReleases = pressReleases.filter(filter);

--- a/blocks/press-releases/press-releases.js
+++ b/blocks/press-releases/press-releases.js
@@ -8,6 +8,7 @@ import {
   createOptimizedPicture,
   readBlockConfig,
 } from '../../scripts/lib-franklin.js';
+import { getOrigin } from '../../scripts/lib-franklin.js';
 
 const stopWords = ['a', 'an', 'the', 'and', 'to', 'for', 'i', 'of', 'on', 'into'];
 
@@ -44,7 +45,8 @@ function createFilter(pressReleases, activeFilters, createDropdown, createFullTe
 }
 
 function getPressReleases(limit, filter) {
-  const indexUrl = new URL('/press-releases.json', window.location.origin);
+  
+  const indexUrl = new URL('/press-releases.json', getOrigin());
   let pressReleases = ffetch(indexUrl);
   if (filter) pressReleases = pressReleases.filter(filter);
   if (limit) pressReleases = pressReleases.limit(limit);

--- a/blocks/related-articles/related-articles.js
+++ b/blocks/related-articles/related-articles.js
@@ -5,6 +5,7 @@ import {
 import {
   createOptimizedPicture,
   getMetadata,
+  getOrigin,
   toClassName,
 } from '../../scripts/lib-franklin.js';
 
@@ -60,7 +61,7 @@ async function createRelatedtMagazineArticles(mainEl, magazineArticles) {
 }
 
 async function getRelatedMagazineArticles() {
-  const indexUrl = new URL('/magazine-articles.json', window.location.origin);
+  const indexUrl = new URL('/magazine-articles.json', getOrigin());
   const articles = ffetch(indexUrl).all();
   return articles;
 }

--- a/news-and-stories/press-releases/feed.xml
+++ b/news-and-stories/press-releases/feed.xml
@@ -8,2568 +8,2568 @@
     <subtitle>Volvo Trucks USA Press Releases</subtitle>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues Leading the Shift Towards Sustainable Transport Solutions, Tripling the Number of Certified EV Dealerships in One Year]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-continues-leading-the-shift-towards-sustainable-transport-solutions-tripling-the-number-of-certified-ev-dealerships-in-one-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-continues-leading-the-shift-towards-sustainable-transport-solutions-tripling-the-number-of-certified-ev-dealerships-in-one-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-continues-leading-the-shift-towards-sustainable-transport-solutions-tripling-the-number-of-certified-ev-dealerships-in-one-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-continues-leading-the-shift-towards-sustainable-transport-solutions-tripling-the-number-of-certified-ev-dealerships-in-one-year/"/>
         <updated>2023-05-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Trucks Certified EV Dealership program was designed to ensure the robust sales and service ecosystem required to support customers with the commercial deployment of Class 8 battery-electric trucks.]]></content>
         <published>2023-05-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Simplifies Truck Maintenance and Boosts Uptime with Volvo Blue Service Contract for Intelligent Maintenance]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-simplifies-truck-maintenance-and-boosts-uptime-with-volvo-blue-service-contract-for-intelligent-maintenance/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-simplifies-truck-maintenance-and-boosts-uptime-with-volvo-blue-service-contract-for-intelligent-maintenance/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-simplifies-truck-maintenance-and-boosts-uptime-with-volvo-blue-service-contract-for-intelligent-maintenance/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-simplifies-truck-maintenance-and-boosts-uptime-with-volvo-blue-service-contract-for-intelligent-maintenance/"/>
         <updated>2023-05-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[“As trucks become more technologically advanced and the value of uptime continues to increase exponentially, fleets are recognizing the value of having a dedicated, Volvo Trucks fleet manager at their local dealership to provide intelligent, data driven maintenance, on a schedule which maximizes uptime through minimizing visits to the shop.” said Peter Voorhoeve, president, Volvo Trucks North America.]]></content>
         <published>2023-05-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces Gateway Truck & Refrigeration as First Volvo Trucks Certified EV Dealer in Illinois]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-announces-gateway-truck-and-refrigeration-as-first-volvo-trucks-certified-ev-dealer-in-illinois/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-announces-gateway-truck-and-refrigeration-as-first-volvo-trucks-certified-ev-dealer-in-illinois/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-announces-gateway-truck-and-refrigeration-as-first-volvo-trucks-certified-ev-dealer-in-illinois/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-announces-gateway-truck-and-refrigeration-as-first-volvo-trucks-certified-ev-dealer-in-illinois/"/>
         <updated>2023-04-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America confirms that Gateway Truck & Refrigeration has completed the rigorous training and facility upgrades to become the first Volvo Trucks Certified Electric Vehicle (EV) Dealership in Illinois.]]></content>
         <published>2023-04-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit Industry-Leading Sustainable Freight Transport Solutions and Supporting Ecosystem at ACT Expo 2023 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/volvo-trucks-to-exhibit-industry-leading-sustainable-freight-transport-solutions-and-supporting-ecosystem-at-act-expo-2023/"/>
         <updated>2023-04-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Anaheim, CA – Volvo Trucks North America will showcase its latest generation Volvo VNR Electric model on the showroom floor at the Advanced Clean Transportation (ACT) Expo at the Anaheim Convention Center on May 1-4, 2023.]]></content>
         <published>2023-04-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Utah PaperBox Deploys First Zero-Tailpipe Emission Volvo VNR Electric Truck in Utah | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/vt-customer-utah-paperbox-deploys-first-zero-tailpipe-emission-volvo-vnr-electric-truck-in-utah/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/vt-customer-utah-paperbox-deploys-first-zero-tailpipe-emission-volvo-vnr-electric-truck-in-utah/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/vt-customer-utah-paperbox-deploys-first-zero-tailpipe-emission-volvo-vnr-electric-truck-in-utah/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/vt-customer-utah-paperbox-deploys-first-zero-tailpipe-emission-volvo-vnr-electric-truck-in-utah/"/>
         <updated>2023-04-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer Utah PaperBox, a 109-year-old family-owned business that has delivered paper products in the Salt Lake City region for five generations, has become the first company in Utah to invest in a zero-tailpipe emission Volvo VNR Electric truck.]]></content>
         <published>2023-04-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[With Volvo Partnership, Coke Canada Bottling to Become First Food and Beverage Manufacturer in Canada to Use Electric Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/coke-canada-bottling-to-become-first-food-and-beverage-manufacturer-in-canada-to-use-electric-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/april/coke-canada-bottling-to-become-first-food-and-beverage-manufacturer-in-canada-to-use-electric-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/coke-canada-bottling-to-become-first-food-and-beverage-manufacturer-in-canada-to-use-electric-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/april/coke-canada-bottling-to-become-first-food-and-beverage-manufacturer-in-canada-to-use-electric-trucks/"/>
         <updated>2023-04-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Montreal, Quebec — Volvo Trucks North America today announced Coca-Cola Canada Bottling Limited (Coke Canada Bottling) is acquiring six Volvo VNR Electric trucks, as part of a pilot program to service their iconic ‘Red Fleet’ customer delivery routes throughout the Greater Montreal Area.]]></content>
         <published>2023-04-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces 2022 Dealer Group of the Year Award Winners for the U.S. and Canada | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/march/volvo-trucks-announces-2022-dealer-group-of-the-year-award-winners-for-the-us-and-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/march/volvo-trucks-announces-2022-dealer-group-of-the-year-award-winners-for-the-us-and-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/march/volvo-trucks-announces-2022-dealer-group-of-the-year-award-winners-for-the-us-and-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/march/volvo-trucks-announces-2022-dealer-group-of-the-year-award-winners-for-the-us-and-canada/"/>
         <updated>2023-03-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America named two of its North American dealers as U.S. and Canada Dealer Groups of the Year. Massachusetts-based Ballard Truck Center was named the 2022 U.S. Dealer Group of the Year and Sheehan’s Truck Centre in Ontario was named the 2022 Canadian Dealer Group of the Year.]]></content>
         <published>2023-03-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Launches Comprehensive Volvo Blue Service Contract to North American Customers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-launches-comprehensive-volvo-blue-service-contract-to-north-american-customers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-launches-comprehensive-volvo-blue-service-contract-to-north-american-customers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-launches-comprehensive-volvo-blue-service-contract-to-north-american-customers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-launches-comprehensive-volvo-blue-service-contract-to-north-american-customers/"/>
         <updated>2023-02-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that the Volvo Blue service contract — its adaptive, dealer managed service plan, which is paired with enhanced connectivity and covers all preventative maintenance, is now available to customers across North America.]]></content>
         <published>2023-02-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces Connected Vehicle Analytics Tool to Maximize Vehicle Efficiency and Productivity | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/vt-introduces-connected-vehicle-analytics-tool-to-maximize-vehicle-efficiency-and-productivity/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/vt-introduces-connected-vehicle-analytics-tool-to-maximize-vehicle-efficiency-and-productivity/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/vt-introduces-connected-vehicle-analytics-tool-to-maximize-vehicle-efficiency-and-productivity/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/vt-introduces-connected-vehicle-analytics-tool-to-maximize-vehicle-efficiency-and-productivity/"/>
         <updated>2023-02-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America rolled out a new connected technology tool for its dealers to help fleet customers maximize both fuel efficiency and vehicle productivity.]]></content>
         <published>2023-02-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Doubles the Updatable Modules for Remote Programming, Boosting Customer Uptime | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-doubles-the-updatable-modules-for-remote-programming-boosting-customer-uptime/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-doubles-the-updatable-modules-for-remote-programming-boosting-customer-uptime/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-doubles-the-updatable-modules-for-remote-programming-boosting-customer-uptime/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-doubles-the-updatable-modules-for-remote-programming-boosting-customer-uptime/"/>
         <updated>2023-02-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America recently announced an expansion to its Remote Diagnostics bundle by adding three new updateable modules to the Remote Programming service.]]></content>
         <published>2023-02-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Electromobility Ecosystem Surpasses 25 Certified EV Dealerships | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-electromobility-ecosystem-surpasses-25-certified-ev-dealerships/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-electromobility-ecosystem-surpasses-25-certified-ev-dealerships/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-electromobility-ecosystem-surpasses-25-certified-ev-dealerships/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-electromobility-ecosystem-surpasses-25-certified-ev-dealerships/"/>
         <updated>2023-02-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has surpassed an important milestone in preparing its national dealer network to support customers with the deployment of its zero-tailpipe emission Volvo VNR Electric model]]></content>
         <published>2023-02-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Drivers Experience Fuel Efficiency without Compromise with Volvo Trucks I-Torque | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/drivers-experience-fuel-efficiency-without-compromise-with-volvo-trucks-i-torque/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/drivers-experience-fuel-efficiency-without-compromise-with-volvo-trucks-i-torque/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/drivers-experience-fuel-efficiency-without-compromise-with-volvo-trucks-i-torque/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/drivers-experience-fuel-efficiency-without-compromise-with-volvo-trucks-i-torque/"/>
         <updated>2023-02-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is proud to report that fleets across North America are increasingly choosing to spec trucks with Volvo I-Torque technology — its innovative powertrain solution that delivers best-in-class fuel efficiency for Class 8 diesel freight trucks.]]></content>
         <published>2023-02-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands Access to EV Chargers with Additions to Vendor Direct Shipping Program]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-expands-access-to-ev-chargers-with-additions-to-vendor-direct-shipping-program/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/volvo-trucks-expands-access-to-ev-chargers-with-additions-to-vendor-direct-shipping-program/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-expands-access-to-ev-chargers-with-additions-to-vendor-direct-shipping-program/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/volvo-trucks-expands-access-to-ev-chargers-with-additions-to-vendor-direct-shipping-program/"/>
         <updated>2023-02-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has added an additional vendor, Gilbarco Veeder-Root, to its Vendor Direct Shipping program, further enabling customers to procure mobile and fixed electric vehicle (EV) charging hardware solutions directly from Volvo Trucks dealers when they purchase Volvo VNR Electric trucks.]]></content>
         <published>2023-02-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Showcases Proof Points on Freight Efficiency, Sustainability and Maximizing Uptime at TMC 2023]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/vt-showcases-proof-points-on-freight-efficiency-sustainability-and-maximizing-uptime-at-tmc-2023/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/vt-showcases-proof-points-on-freight-efficiency-sustainability-and-maximizing-uptime-at-tmc-2023/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/vt-showcases-proof-points-on-freight-efficiency-sustainability-and-maximizing-uptime-at-tmc-2023/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/vt-showcases-proof-points-on-freight-efficiency-sustainability-and-maximizing-uptime-at-tmc-2023/"/>
         <updated>2023-02-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will showcase the 2022 Volvo VNL 760 “Purple Haze”, a VNL 760 equipped with the latest D13 Turbo Compound and I-Torque at the American Trucking Associations’ Technology & Maintenance Council (TMC) 2023 Spring Meeting from February 27-March 2 at the Orange County Convention Center in Orlando, Florida.]]></content>
         <published>2023-02-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Carriers Scale Up Volvo VNR Electric Fleets for Zero-Tailpipe Emission Deliveries to Volvo Group Assembly Plants]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/carriers-scale-up-for-zero-tailpipe-emission-deliveries-to-volvo-group-assembly-plants/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/carriers-scale-up-for-zero-tailpipe-emission-deliveries-to-volvo-group-assembly-plants/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/carriers-scale-up-for-zero-tailpipe-emission-deliveries-to-volvo-group-assembly-plants/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/carriers-scale-up-for-zero-tailpipe-emission-deliveries-to-volvo-group-assembly-plants/"/>
         <updated>2023-02-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America continues to demonstrate its commitment to reducing the carbon footprint of its supply chain by scaling up the number of zero-tailpipe emission Volvo VNR Electric trucks that service its North American assembly plants.]]></content>
         <published>2023-02-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Record year for Volvo Trucks in 2022 – all-time high volumes and market share increase in 41 countries| Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/record-year-for-volvo-trucks-in-2022-all-time-high-volumes-and-market-share-increase-in-41-countries/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/february/record-year-for-volvo-trucks-in-2022-all-time-high-volumes-and-market-share-increase-in-41-countries/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/record-year-for-volvo-trucks-in-2022-all-time-high-volumes-and-market-share-increase-in-41-countries/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/february/record-year-for-volvo-trucks-in-2022-all-time-high-volumes-and-market-share-increase-in-41-countries/"/>
         <updated>2023-02-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2022 was a record year for Volvo Trucks. The company delivered an all-time high number of its trucks to customers and also increased its market share in 41 countries.]]></content>
         <published>2023-02-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[TEC Equipment – Portland Becomes First Volvo Trucks Certified EV Dealer in Oregon | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/tec-equipment-portland-becomes-first-volvo-trucks-certified-ev-dealer-in-oregon/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/tec-equipment-portland-becomes-first-volvo-trucks-certified-ev-dealer-in-oregon/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/tec-equipment-portland-becomes-first-volvo-trucks-certified-ev-dealer-in-oregon/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/tec-equipment-portland-becomes-first-volvo-trucks-certified-ev-dealer-in-oregon/"/>
         <updated>2023-01-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced that its largest West Coast dealer group, TEC Equipment, has completed the Volvo Trucks Certified Electric Vehicle (EV) Dealership training program at its fourth location in Portland, Oregon.]]></content>
         <published>2023-01-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands East Coast Certified EV Dealer Network with Bergey’s Truck Centers in New Jersey | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/volvo-trucks-expands-east-coast-certified-ev-dealer-network-with-bergey-s-truck-centers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/volvo-trucks-expands-east-coast-certified-ev-dealer-network-with-bergey-s-truck-centers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/volvo-trucks-expands-east-coast-certified-ev-dealer-network-with-bergey-s-truck-centers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/volvo-trucks-expands-east-coast-certified-ev-dealer-network-with-bergey-s-truck-centers/"/>
         <updated>2023-01-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has named Bergey’s Truck Centers, a fourth-generation, family run dealership group, as the second Volvo Trucks Certified Electric Vehicle (EV) Dealer in New Jersey.]]></content>
         <published>2023-01-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[General Truck Sales Earns First Volvo Trucks Certified EV Dealer Designation in Indiana | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/general-truck-sales-earns-first-volvo-trucks-certified-ev-dealer-designation-in-indiana/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/general-truck-sales-earns-first-volvo-trucks-certified-ev-dealer-designation-in-indiana/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/general-truck-sales-earns-first-volvo-trucks-certified-ev-dealer-designation-in-indiana/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/general-truck-sales-earns-first-volvo-trucks-certified-ev-dealer-designation-in-indiana/"/>
         <updated>2023-01-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer General Truck Sales has completed the necessary training and facility upgrades to earn the Volvo Trucks Certified Electric Vehicle (EV) Dealer designation at two of its flagship locations — Toledo, Ohio, and Pendleton, Indiana — both of which are positioned near major interstates to service fleet customers throughout the Midwest.]]></content>
         <published>2023-01-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Rockview Farms Deploys Volvo LIGHTS Project s Final Two Volvo VNR Electric Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/rockview-farms-deploys-volvo-lights-project-s-final-two-volvo-vnr-electric-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2023/january/rockview-farms-deploys-volvo-lights-project-s-final-two-volvo-vnr-electric-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/rockview-farms-deploys-volvo-lights-project-s-final-two-volvo-vnr-electric-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2023/january/rockview-farms-deploys-volvo-lights-project-s-final-two-volvo-vnr-electric-trucks/"/>
         <updated>2023-01-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer Rockview Farms, a family owned and operated dairy business in Southern California, deployed two Volvo VNR Electric trucks to support farm-to-customer deliveries of local California milk.]]></content>
         <published>2023-01-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Young Trucks Becomes First Volvo Trucks Certified EV Dealership in Ohio | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/young-trucks-becomes-first-volvo-trucks-certified-ev-dealership-in-ohio/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/young-trucks-becomes-first-volvo-trucks-certified-ev-dealership-in-ohio/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/young-trucks-becomes-first-volvo-trucks-certified-ev-dealership-in-ohio/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/young-trucks-becomes-first-volvo-trucks-certified-ev-dealership-in-ohio/"/>
         <updated>2022-12-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has expanded its network of Volvo Trucks Certified Electric Vehicle (EV) Dealers into Ohio, announcing that Young Trucks, a fourth generation, family-owned dealership, has recently completed the required training and certification program.]]></content>
         <published>2022-12-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Jared Ruiz Named Regional Vice President West Volvo Trucks North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/jared-ruiz-named-regional-vice-president-west-volvo-trucks-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/jared-ruiz-named-regional-vice-president-west-volvo-trucks-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/jared-ruiz-named-regional-vice-president-west-volvo-trucks-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/jared-ruiz-named-regional-vice-president-west-volvo-trucks-north-america/"/>
         <updated>2022-12-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Jared Ruiz has been appointed Regional Vice President – West for Volvo Trucks North America. He begins his new position on January 3, 2023.]]></content>
         <published>2022-12-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Surgenor Truck Group’s Two Ontario, Canada, Locations Become Volvo Trucks Certified EV Dealers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/surgenor-truck-group-s-two-ontario-canada-locations-become-volvo-trucks-certified-ev-dealers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/surgenor-truck-group-s-two-ontario-canada-locations-become-volvo-trucks-certified-ev-dealers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/surgenor-truck-group-s-two-ontario-canada-locations-become-volvo-trucks-certified-ev-dealers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/surgenor-truck-group-s-two-ontario-canada-locations-become-volvo-trucks-certified-ev-dealers/"/>
         <updated>2022-12-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced the sixth and seventh Canadian dealerships to complete its comprehensive Volvo Trucks Certified Electric Vehicle (EV) Dealer program. Surgenor Truck Group, a family owned and operated truck dealership for more than 30 years.]]></content>
         <published>2022-12-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Vision Truck Group as Fifth Certified EV Dealer in Canada | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/vision-truck-group-as-fifth-certified-ev-dealer-in-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/vision-truck-group-as-fifth-certified-ev-dealer-in-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/vision-truck-group-as-fifth-certified-ev-dealer-in-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/vision-truck-group-as-fifth-certified-ev-dealer-in-canada/"/>
         <updated>2022-12-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America named Vision Truck Group as the first Volvo Trucks Certified Electric Vehicle (EV) Dealer in the Greater Toronto Area of Ontario, Canada. Vision Truck Group, a second-generation, family-owned dealership group, has served the heavy-duty trucking industry for more than 50 years, providing sales, service, modifications, and parts across a network of dealerships in Southwestern Ontario, Canada.]]></content>
         <published>2022-12-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Ryder Deploys Volvo VNR Electric Trucks to Service Volvo Group s Assembly Operations | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/ryder-deploys-volvo-vnr-electric-trucks-to-service-volvo-group-s-assembly-operations/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/ryder-deploys-volvo-vnr-electric-trucks-to-service-volvo-group-s-assembly-operations/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/ryder-deploys-volvo-vnr-electric-trucks-to-service-volvo-group-s-assembly-operations/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/ryder-deploys-volvo-vnr-electric-trucks-to-service-volvo-group-s-assembly-operations/"/>
         <updated>2022-12-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has delivered seven Volvo VNR Electric trucks to Ryder System, Inc. (NYSE: R) to support local supply chain routes servicing the Volvo Group’s truck assembly operations in Pennsylvania.]]></content>
         <published>2022-12-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Pacific Coast Heavy Truck Group Becomes First Volvo Trucks Certified EV Dealer in British Columbia Canada| Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/pacific-coast-heavy-truck-group-becomes-first-volvo-trucks-certified-ev-dealer-in-british-columbia/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/december/pacific-coast-heavy-truck-group-becomes-first-volvo-trucks-certified-ev-dealer-in-british-columbia/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/pacific-coast-heavy-truck-group-becomes-first-volvo-trucks-certified-ev-dealer-in-british-columbia/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/december/pacific-coast-heavy-truck-group-becomes-first-volvo-trucks-certified-ev-dealer-in-british-columbia/"/>
         <updated>2022-12-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today announced the expansion of its certified electric vehicle (EV) dealer network into a third Canadian province to support continued market adoption of its Class 8 Volvo VNR Electric model.]]></content>
         <published>2022-12-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo VNR Electric Trucks Deployed in South Bronx Via 10 Million New York Clean Transportation Prize | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/november/volvo-vnr-electric-trucks-deployed-in-south-bronx-via-10-million-new-york-clean-transportation-prize/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/november/volvo-vnr-electric-trucks-deployed-in-south-bronx-via-10-million-new-york-clean-transportation-prize/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/november/volvo-vnr-electric-trucks-deployed-in-south-bronx-via-10-million-new-york-clean-transportation-prize/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/november/volvo-vnr-electric-trucks-deployed-in-south-bronx-via-10-million-new-york-clean-transportation-prize/"/>
         <updated>2022-11-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will deploy eight Volvo VNR Electric trucks with two Bronx-based community groups as part of a $10 million award through the New York Clean Transportation Prizes program.]]></content>
         <published>2022-11-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo and Pilot Company partner to Build a National Public Heavy-Duty Charging Network | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/november/volvo-and-pilot-company-partner-to-build-a-national-public-heavy-duty-charging-network/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/november/volvo-and-pilot-company-partner-to-build-a-national-public-heavy-duty-charging-network/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/november/volvo-and-pilot-company-partner-to-build-a-national-public-heavy-duty-charging-network/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/november/volvo-and-pilot-company-partner-to-build-a-national-public-heavy-duty-charging-network/"/>
         <updated>2022-11-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Group and Pilot Company, the largest operator of travel centers in North America, have signed a Letter of Intent to develop a national, public charging network to support the scaling of battery-electric Volvo VNR Electric trucks.]]></content>
         <published>2022-11-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Extends Exclusive Sponsorship of America’s Road Team for 2023]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2023/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2023/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2023/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2023/"/>
         <updated>2022-10-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will enter its 21st consecutive year as the exclusive sponsor of the America’s Road Team public outreach program in 2023. Peter Voorhoeve, president of Volvo Trucks North America, made the announcement at the American Trucking Associations’ (ATA) Management Conference & Exhibition (MC&E) in Nashville, Tennessee.]]></content>
         <published>2022-10-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ Electromobility Total Cost of Ownership Tool Demonstrates Financial, Environmental Benefits of Volvo VNR Electric]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/total-cost-of-ownership-tool-demonstrates-financial-environmental-benefits-of-volvo-vnr-electric/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/total-cost-of-ownership-tool-demonstrates-financial-environmental-benefits-of-volvo-vnr-electric/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/total-cost-of-ownership-tool-demonstrates-financial-environmental-benefits-of-volvo-vnr-electric/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/total-cost-of-ownership-tool-demonstrates-financial-environmental-benefits-of-volvo-vnr-electric/"/>
         <updated>2022-10-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has introduced a new electromobility total cost of ownership (TCO) tool to support customers to make fact-based decisions about the business impact of purchasing and operating zero-tailpipe emission battery-electric trucks.]]></content>
         <published>2022-10-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Tradelink Transport Transforming Fleet by Nearly 30% with VNR Electric Trucks to Decarbonize Transportation and Recruit Drivers of the Future]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/tradelink-transport-transforming-with-vnr-electric-trucks-to-decarbonize-transportation/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/tradelink-transport-transforming-with-vnr-electric-trucks-to-decarbonize-transportation/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/tradelink-transport-transforming-with-vnr-electric-trucks-to-decarbonize-transportation/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/tradelink-transport-transforming-with-vnr-electric-trucks-to-decarbonize-transportation/"/>
         <updated>2022-10-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer Tradelink Transport, a minority-owned trucking company based in Compton, California, recently purchased 15 Volvo VNR Electric trucks for its land-bridge operations transporting a variety of products for major shipping companies between the ports of Los Angeles and Long Beach and nearby rail yards.]]></content>
         <published>2022-10-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Showcase Advanced Vehicle Technologies at ATA MC&amp;E]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/volvo-trucks-to-showcase-advanced-vehicle-technologies-at-ata-mc-and-e/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/volvo-trucks-to-showcase-advanced-vehicle-technologies-at-ata-mc-and-e/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/volvo-trucks-to-showcase-advanced-vehicle-technologies-at-ata-mc-and-e/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/volvo-trucks-to-showcase-advanced-vehicle-technologies-at-ata-mc-and-e/"/>
         <updated>2022-10-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will showcase a portfolio of advanced transportation solutions for Class 8 trucks at the American Trucking Associations’ (ATA) 2022 Management Conference & Exhibition (MC&E), October 22-25, in San Diego, California.]]></content>
         <published>2022-10-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[25,000 Trucks Delivered to Penske Truck Leasing in a Ceremony at the Volvo Customer Center | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/vtna-celebrates-25000-trucks-delivered-to-penske-truck-leasing/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/vtna-celebrates-25000-trucks-delivered-to-penske-truck-leasing/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/vtna-celebrates-25000-trucks-delivered-to-penske-truck-leasing/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/vtna-celebrates-25000-trucks-delivered-to-penske-truck-leasing/"/>
         <updated>2022-10-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America hosted Penske Truck Leasing executives at the Volvo Trucks Customer Center in Dublin, Va. today to commemorate the delivery of the 25,000th truck in a partnership that has spanned the last two decades.]]></content>
         <published>2022-10-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Performance Team Scales Volvo VNR Electric Fleet, Supported by TEC Equipment | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/performance-team-scales-volvo-vnr-electric-fleet-supported-by-tec-equipment/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/october/performance-team-scales-volvo-vnr-electric-fleet-supported-by-tec-equipment/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/performance-team-scales-volvo-vnr-electric-fleet-supported-by-tec-equipment/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/october/performance-team-scales-volvo-vnr-electric-fleet-supported-by-tec-equipment/"/>
         <updated>2022-10-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America’s largest West Coast dealership, TEC Equipment is working with Performance Team to integrate its growing battery-electric fleet into its Southern California operations.]]></content>
         <published>2022-10-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Simplifies EV Charger Procurement with Vendor Direct Shipping Program]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/volvo-trucks-simplifies-ev-charger-procurement-with-vendor-direct-shipping-program/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/volvo-trucks-simplifies-ev-charger-procurement-with-vendor-direct-shipping-program/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/volvo-trucks-simplifies-ev-charger-procurement-with-vendor-direct-shipping-program/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/volvo-trucks-simplifies-ev-charger-procurement-with-vendor-direct-shipping-program/"/>
         <updated>2022-09-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is pleased to announce a new program to provide streamlined access to electric vehicle (EV) charging offerings for dealers and fleet customers.]]></content>
         <published>2022-09-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Announces Nuss Truck &amp; Equipment as the First Certified EV Dealer in the Midwest]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/volvo-trucks-na-announces-nuss-truck-equipment-as-the-first-certified-ev-dealer-in-the-midwest/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/volvo-trucks-na-announces-nuss-truck-equipment-as-the-first-certified-ev-dealer-in-the-midwest/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/volvo-trucks-na-announces-nuss-truck-equipment-as-the-first-certified-ev-dealer-in-the-midwest/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/volvo-trucks-na-announces-nuss-truck-equipment-as-the-first-certified-ev-dealer-in-the-midwest/"/>
         <updated>2022-09-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America confirmed the expansion of its certified electric vehicle dealer network into America’s Heartland with the certification of Nuss Truck & Equipment’s Roseville, Minnesota location.]]></content>
         <published>2022-09-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Expressway Trucks Becomes First Volvo Trucks Certified EV Dealer in Ontario, Canada | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/expressway-trucks-becomes-first-volvo-trucks-certified-ev-dealer-in-ontario-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/expressway-trucks-becomes-first-volvo-trucks-certified-ev-dealer-in-ontario-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/expressway-trucks-becomes-first-volvo-trucks-certified-ev-dealer-in-ontario-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/expressway-trucks-becomes-first-volvo-trucks-certified-ev-dealer-in-ontario-canada/"/>
         <updated>2022-09-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has recently designated Expressway Trucks as a Volvo Trucks Certified Electric Vehicle (EV) Dealer, signifying that it is ready to support customers interested in adding Volvo VNR Electrics to their local and regional distribution, pickup and delivery, and food and beverage distribution routes.]]></content>
         <published>2022-09-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[4 Gen Logistics to Deploy 41 Volvo VNR Electric Trucks to Service the Port of Long Beach | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/4-gen-logistics-to-deploy-41-volvo-vnr-electric-trucks-to-service-the-port-of-long-beach/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/september/4-gen-logistics-to-deploy-41-volvo-vnr-electric-trucks-to-service-the-port-of-long-beach/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/4-gen-logistics-to-deploy-41-volvo-vnr-electric-trucks-to-service-the-port-of-long-beach/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/september/4-gen-logistics-to-deploy-41-volvo-vnr-electric-trucks-to-service-the-port-of-long-beach/"/>
         <updated>2022-09-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer 4 Gen Logistics, a fourth generation, family-owned drayage company, has ordered 41 Volvo VNR Electric trucks to haul freight between the Port of Long Beach and Southern California’s Inland Empire, a national logistics and warehousing hub.]]></content>
         <published>2022-09-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Award-Winning Volvo LIGHTS Project Wraps in Southern California | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/august/award-winning-volvo-lights-project-wraps-in-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/august/award-winning-volvo-lights-project-wraps-in-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/august/award-winning-volvo-lights-project-wraps-in-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/august/award-winning-volvo-lights-project-wraps-in-southern-california/"/>
         <updated>2022-08-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced the culmination of the Volvo LIGHTS project – an innovative three-year project that brought together 14 public and private partners to design and implement a blueprint for the robust support ecosystem necessary to deploy battery-electric trucks and equipment at scale.]]></content>
         <published>2022-08-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[McLane Company Integrates VNR Electric Trucks Into Southern California Supply Chain Logistics | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/august/mclane-company-integrates-volvo-vnr-electric-trucks-into-southern-california-supply-chain-logistics/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/august/mclane-company-integrates-volvo-vnr-electric-trucks-into-southern-california-supply-chain-logistics/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/august/mclane-company-integrates-volvo-vnr-electric-trucks-into-southern-california-supply-chain-logistics/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/august/mclane-company-integrates-volvo-vnr-electric-trucks-into-southern-california-supply-chain-logistics/"/>
         <updated>2022-08-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer McLane Company, one of the largest supply chain services leaders in the U.S., is taking delivery of three Volvo VNR Electric trucks to provide zero-tailpipe emission deliveries in Southern California.]]></content>
         <published>2022-08-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Gabrielli Truck Sales Becomes Volvo Trucks Certified EV Dealer]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/gabrielli-truck-sales-becomes-volvo-trucks-certified-ev-dealer/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/gabrielli-truck-sales-becomes-volvo-trucks-certified-ev-dealer/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/gabrielli-truck-sales-becomes-volvo-trucks-certified-ev-dealer/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/gabrielli-truck-sales-becomes-volvo-trucks-certified-ev-dealer/"/>
         <updated>2022-07-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has designated Gabrielli Truck Sales, one of the largest and oldest commercial truck dealers in the Northeast, as a Volvo Trucks Certified Electric Vehicle (EV) Dealer]]></content>
         <published>2022-07-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Constructing California Electrified Charging Corridor for Medium- and Heavy-Duty Electric Vehicles]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/constructing-california-electrified-charging-corridor-for-medium-and-heavy-duty-electric-vehicles/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/constructing-california-electrified-charging-corridor-for-medium-and-heavy-duty-electric-vehicles/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/constructing-california-electrified-charging-corridor-for-medium-and-heavy-duty-electric-vehicles/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/constructing-california-electrified-charging-corridor-for-medium-and-heavy-duty-electric-vehicles/"/>
         <updated>2022-07-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that is joining forces with Volvo Financial Services, Volvo Technology of America, Shell Recharge Solutions, TEC Equipment, Affinity Truck Center, and Western Truck Center to develop a publicly accessible medium- and heavy-duty electric vehicle (MHD EV) charging network that connects several of California’s largest metropolitan areas.]]></content>
         <published>2022-07-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Kyle Zimmerman Appointed Public Relations Manager for Volvo Trucks North America]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/kyle-zimmerman-appointed-public-relations-manager-for-volvo-trucks-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/july/kyle-zimmerman-appointed-public-relations-manager-for-volvo-trucks-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/kyle-zimmerman-appointed-public-relations-manager-for-volvo-trucks-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/july/kyle-zimmerman-appointed-public-relations-manager-for-volvo-trucks-north-america/"/>
         <updated>2022-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Kyle Zimmerman is appointed public relations manager for Volvo Trucks North America. Kyle begins his new position on July 11, 2022.]]></content>
         <published>2022-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Ballard Truck Center Becomes First Volvo Trucks Certified EV Dealer in New England]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/ballard-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-new-england/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/ballard-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-new-england/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/ballard-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-new-england/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/ballard-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-new-england/"/>
         <updated>2022-06-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Ballard Truck Center, a fifth-generation family-owned business, recently became the first Volvo Truck Certified Electric Vehicle (EV) Dealer in Massachusetts at its Tewksbury location.]]></content>
         <published>2022-06-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Nacarato Truck Center Becomes First Volvo Trucks Certified EV Dealership in Tennessee]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/nacarato-truck-center-becomes-first-volvo-trucks-certified-ev-dealership-in-tennessee/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/nacarato-truck-center-becomes-first-volvo-trucks-certified-ev-dealership-in-tennessee/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/nacarato-truck-center-becomes-first-volvo-trucks-certified-ev-dealership-in-tennessee/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/nacarato-truck-center-becomes-first-volvo-trucks-certified-ev-dealership-in-tennessee/"/>
         <updated>2022-06-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Nacarato Truck Centers, a third-generation family run dealership group, completed the required training and facility updates to become the first Volvo Trucks Certified Electric Vehicle (EV) Dealership in Tennessee with its La Vergne location, servicing the greater Nashville market.]]></content>
         <published>2022-06-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Expands Capabilities of Industry-Leading I-Shift Transmission with Dual Power Take-off]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/volvo-trucks-na-expands-capabilities-of-industry-leading-i-shift-with-dual-power-take-off/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/june/volvo-trucks-na-expands-capabilities-of-industry-leading-i-shift-with-dual-power-take-off/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/volvo-trucks-na-expands-capabilities-of-industry-leading-i-shift-with-dual-power-take-off/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/june/volvo-trucks-na-expands-capabilities-of-industry-leading-i-shift-with-dual-power-take-off/"/>
         <updated>2022-06-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America upgrades I-Shift, the industry’s most advanced automated manual transmission with digital intelligence. I-Shift now offers a dual power take-off (PTO) that expands the efficiency benefits, transmission functionality and overall cost savings.]]></content>
         <published>2022-06-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Academy Opens New Facility to Better Serve Electric Truck Training]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-academy-opens-new-facility-to-better-serve-electric-truck-training/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-academy-opens-new-facility-to-better-serve-electric-truck-training/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-academy-opens-new-facility-to-better-serve-electric-truck-training/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-academy-opens-new-facility-to-better-serve-electric-truck-training/"/>
         <updated>2022-05-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that the Volvo Trucks Academy opened a new facility in Tinley Park, Illinois, to expand access to battery-electric truck training in the central U.S. The new 14,865-square-foot facility is larger and more modern than the previous Illinois training facility, enabling Volvo Trucks to provide more robust, hands-on learning opportunities for customers and dealers interested in electromobility solutions, including the Volvo VNR Electric model.]]></content>
         <published>2022-05-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Fleetmaster Express Set to Receive First VNR Electric Trucks in Texas to Service Ball Corporation | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/fleetmaster-express-to-receive-first-volvo-vnr-electric-trucks-in-texas-to-service-ball-corporation/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/fleetmaster-express-to-receive-first-volvo-vnr-electric-trucks-in-texas-to-service-ball-corporation/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/fleetmaster-express-to-receive-first-volvo-vnr-electric-trucks-in-texas-to-service-ball-corporation/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/fleetmaster-express-to-receive-first-volvo-vnr-electric-trucks-in-texas-to-service-ball-corporation/"/>
         <updated>2022-05-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer Fleetmaster Express, a for-hire logistics carrier, has ordered 10 Volvo VNR Electrics to support supply chain sustainability efforts for Ball Corporation, a leading global provider of infinitely recyclable aluminum beverage packaging.]]></content>
         <published>2022-05-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Bruckner’s Truck &amp; Equipment Becomes First Volvo Trucks Certified EV Dealer in Texas]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/bruckners-truck-equipment-becomes-first-volvo-trucks-certified-ev-dealer-in-texas/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/bruckners-truck-equipment-becomes-first-volvo-trucks-certified-ev-dealer-in-texas/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/bruckners-truck-equipment-becomes-first-volvo-trucks-certified-ev-dealer-in-texas/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/bruckners-truck-equipment-becomes-first-volvo-trucks-certified-ev-dealer-in-texas/"/>
         <updated>2022-05-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer Bruckner’s Truck & Equipment in Fort Worth, Texas, completed the rigorous training process to become the first Volvo Trucks Certified Electric Vehicle (EV) Dealer in the Lone Star State.]]></content>
         <published>2022-05-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo LIGHTS Lessons Learned Guidebook Highlights Key Learnings from Three-Year Fleet Electrification Project | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-lights-lessons-learned-guidebook-highlights-key-learnings/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-lights-lessons-learned-guidebook-highlights-key-learnings/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-lights-lessons-learned-guidebook-highlights-key-learnings/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-lights-lessons-learned-guidebook-highlights-key-learnings/"/>
         <updated>2022-05-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Group North America has published a Volvo LIGHTS (Low Impact Green Heavy-Transport Solutions) Lessons Learned Guidebook to commemorate the end]]></content>
         <published>2022-05-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[PITT OHIO Begins Operation of First VNR Electric Trucks in Ohio | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/pitt-ohio-begins-operation-of-first-volvo-vnr-electric-trucks-in-ohio/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/pitt-ohio-begins-operation-of-first-volvo-vnr-electric-trucks-in-ohio/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/pitt-ohio-begins-operation-of-first-volvo-vnr-electric-trucks-in-ohio/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/pitt-ohio-begins-operation-of-first-volvo-vnr-electric-trucks-in-ohio/"/>
         <updated>2022-05-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer PITT OHIO — a leader in transportation, warehouse, and logistics services — announced the addition of two Class 7 Volvo VNR Electric box trucks to its Cleveland, Ohio, fleet. The 26-foot battery-electric box trucks will be operated out of PITT OHIO’s Cleveland terminal as part of its LTL freight shipping business.]]></content>
         <published>2022-05-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[NFI Expands Zero-Tailpipe Emission Fleet with Order of 60 VNR Electrics | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/nfi-expands-zero-tailpipe-emission-fleet-with-order-of-60-volvo-vnr-electrics/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/nfi-expands-zero-tailpipe-emission-fleet-with-order-of-60-volvo-vnr-electrics/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/nfi-expands-zero-tailpipe-emission-fleet-with-order-of-60-volvo-vnr-electrics/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/nfi-expands-zero-tailpipe-emission-fleet-with-order-of-60-volvo-vnr-electrics/"/>
         <updated>2022-05-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer, NFI Industries — a leading third-party supply chain solutions provider — is increasing its investment in electromobility solutions with its latest order of 60 Volvo VNR Electric trucks. The battery-electric freight trucks will be deployed in NFI’s Ontario, California fleet throughout 2022 and 2023, in support of its goal of operating the first 100% zero-emission freight logistics fleet in the nation.]]></content>
         <published>2022-05-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer QCD Orders 30 More VNR Electric Trucks for Southern California Fleet]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-customer-qcd-orders-30-more-vnr-electric-trucks-for-southern-california-fleet/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-customer-qcd-orders-30-more-vnr-electric-trucks-for-southern-california-fleet/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-customer-qcd-orders-30-more-vnr-electric-trucks-for-southern-california-fleet/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-customer-qcd-orders-30-more-vnr-electric-trucks-for-southern-california-fleet/"/>
         <updated>2022-05-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer, Quality Custom Distribution (QCD) — a Golden State Foods (GSF) company — is increasing its commitment to zero-tailpipe emission freight transport with its latest order of 30 Volvo VNR Electrics. In early 2023, the battery-electric Class 8 trucks will be deployed in QCD’s Southern California fleet operations delivering products to restaurants and coffee shops throughout Riverside and San Bernardino Counties.]]></content>
         <published>2022-05-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo LIGHTS Project Team Wins 2022 SCAG Sustainability Award for Outstanding Achievement in Sustainability | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-lights-project-team-wins-2022-scag-sustainability-award-for-outstanding-achievement/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-lights-project-team-wins-2022-scag-sustainability-award-for-outstanding-achievement/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-lights-project-team-wins-2022-scag-sustainability-award-for-outstanding-achievement/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-lights-project-team-wins-2022-scag-sustainability-award-for-outstanding-achievement/"/>
         <updated>2022-05-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Southern California Association of Governments (SCAG) has awarded the Volvo LIGHTS (Low Impact Green Heavy Transport Solutions) project — led by South Coast Air Quality Management District (South Coast AQMD) and Volvo Trucks North America.]]></content>
         <published>2022-05-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Autonomous Solutions Introduces Autonomous Transport Solution Targeted | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-autonomous-solutions-introduces-autonomous-transport-solution-targeted/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-autonomous-solutions-introduces-autonomous-transport-solution-targeted/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-autonomous-solutions-introduces-autonomous-transport-solution-targeted/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-autonomous-solutions-introduces-autonomous-transport-solution-targeted/"/>
         <updated>2022-05-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Autonomous Solutions (VAS), a Volvo Group company, introduced today that it will offer a new hub-to-hub autonomous transport solution, designed to serve four main customer segments: shippers; carriers; logistics service providers; and freight brokers.]]></content>
         <published>2022-05-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Hudson County Motors Becomes First Volvo Trucks Certified EV Dealer in New Jersey]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/hudson-county-motors-becomes-first-volvo-trucks-certified-ev-dealer-in-new-jersey/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/hudson-county-motors-becomes-first-volvo-trucks-certified-ev-dealer-in-new-jersey/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/hudson-county-motors-becomes-first-volvo-trucks-certified-ev-dealer-in-new-jersey/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/hudson-county-motors-becomes-first-volvo-trucks-certified-ev-dealer-in-new-jersey/"/>
         <updated>2022-05-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer Hudson County Motors recently became the first Volvo Trucks Certified Electric Vehicle (EV) Dealer in New Jersey]]></content>
         <published>2022-05-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit Volvo VNR Electric Autonomous and Electromobility Solutions at ACT Expo 2022]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-to-exhibit-volvo-vnr-electric-autonomous-and-electromobility-solutions-at-act-expo-2022/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/volvo-trucks-to-exhibit-volvo-vnr-electric-autonomous-and-electromobility-solutions-at-act-expo-2022/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-to-exhibit-volvo-vnr-electric-autonomous-and-electromobility-solutions-at-act-expo-2022/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/volvo-trucks-to-exhibit-volvo-vnr-electric-autonomous-and-electromobility-solutions-at-act-expo-2022/"/>
         <updated>2022-05-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is set to debut its next generation Volvo VNR Electric 6x2 tractor in its booth (#1736) during the Advanced Clean Transportation (ACT) Expo at the Long Beach Convention Center in Long Beach, California, May 9-12, 2022.]]></content>
         <published>2022-05-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[TransEdge Truck Centers Becomes First Volvo Trucks Certified EV Dealer in Pennsylvania]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/transedge-truck-centers-becomes-first-volvo-trucks-certified-ev-dealer-in-pennsylvania/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/may/transedge-truck-centers-becomes-first-volvo-trucks-certified-ev-dealer-in-pennsylvania/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/transedge-truck-centers-becomes-first-volvo-trucks-certified-ev-dealer-in-pennsylvania/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/may/transedge-truck-centers-becomes-first-volvo-trucks-certified-ev-dealer-in-pennsylvania/"/>
         <updated>2022-05-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer TransEdge Truck Centers recently became the first Volvo Trucks Certified Electric Vehicle (EV) Dealer in Pennsylvania after its Pittsburgh location completed the robust staff training program and necessary facility upgrades.]]></content>
         <published>2022-05-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Producers Dairy Deploys First Volvo VNR Electric Trucks to Operate in California’s Central Valley]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/producers-dairy-deploys-first-volvo-vnr-electric-trucks-to-operate-in-california-s-central-valley/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/producers-dairy-deploys-first-volvo-vnr-electric-trucks-to-operate-in-california-s-central-valley/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/producers-dairy-deploys-first-volvo-vnr-electric-trucks-to-operate-in-california-s-central-valley/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/producers-dairy-deploys-first-volvo-vnr-electric-trucks-to-operate-in-california-s-central-valley/"/>
         <updated>2022-04-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Producers Dairy, a dairy processor and direct-to-store supplier, will now deliver quality, farm-to-table freshness with zero tailpipe emissions through the integration of two Volvo VNR Electric trucks into their fleet.]]></content>
         <published>2022-04-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Sue Ann Smith named Vice President of Leasing National Accounts, VTNA | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/sue-ann-smith-named-vice-president-of-leasing-national-accounts/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/sue-ann-smith-named-vice-president-of-leasing-national-accounts/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/sue-ann-smith-named-vice-president-of-leasing-national-accounts/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/sue-ann-smith-named-vice-president-of-leasing-national-accounts/"/>
         <updated>2022-04-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Sue Ann Smith has been appointed Vice President of Leasing National Accounts for Volvo Trucks North America. She began her new position on April 1, 2022.]]></content>
         <published>2022-04-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Martin Brower Integrates First Volvo VNR Electric into its Montreal Fleet to Serve McDonalds | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/martin-brower-integrates-first-volvo-vnr-electric-into-its-montreal-fleet-to-serve-mcdonalds/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/april/martin-brower-integrates-first-volvo-vnr-electric-into-its-montreal-fleet-to-serve-mcdonalds/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/martin-brower-integrates-first-volvo-vnr-electric-into-its-montreal-fleet-to-serve-mcdonalds/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/april/martin-brower-integrates-first-volvo-vnr-electric-into-its-montreal-fleet-to-serve-mcdonalds/"/>
         <updated>2022-04-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America customer Martin Brower, a leading supply chain solutions provider for restaurant chains around the world, has introduced its first Volvo VNR Electric Class 8 tractor to its global fleet.]]></content>
         <published>2022-04-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Receives Largest Global Order for 110 VNR Electric Trucks from Performance Team – a Maersk Company]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-receives-largest-global-order-for-110-vnr-electric-trucks-from-a-maersk-company/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-receives-largest-global-order-for-110-vnr-electric-trucks-from-a-maersk-company/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-receives-largest-global-order-for-110-vnr-electric-trucks-from-a-maersk-company/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-receives-largest-global-order-for-110-vnr-electric-trucks-from-a-maersk-company/"/>
         <updated>2022-03-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has received its largest global order of Class 8 electric trucks to date with Performance Team – A Maersk Company, making a total commitment to purchase 126 Volvo VNR Electric trucks.]]></content>
         <published>2022-03-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Receives Order of 50 Volvo VNR Electric Trucks for WattEV’s Truck-as-a-Service Start Up]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-receives-order-of-50-volvo-vnr-electric-trucks-for-wattev-s-truck-as-a-service-start-up/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-receives-order-of-50-volvo-vnr-electric-trucks-for-wattev-s-truck-as-a-service-start-up/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-receives-order-of-50-volvo-vnr-electric-trucks-for-wattev-s-truck-as-a-service-start-up/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-receives-order-of-50-volvo-vnr-electric-trucks-for-wattev-s-truck-as-a-service-start-up/"/>
         <updated>2022-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America’s customer WattEV has ordered 50 Class 8 Volvo VNR Electric trucks to launch its unique Truck-as-a-Service (TaaS) model in California.]]></content>
         <published>2022-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Introduces I-Torque an Industry-First Powertrain Solution]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-north-america-introduces-i-torque-an-industry-first-powertrain-solution/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-north-america-introduces-i-torque-an-industry-first-powertrain-solution/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-north-america-introduces-i-torque-an-industry-first-powertrain-solution/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-north-america-introduces-i-torque-an-industry-first-powertrain-solution/"/>
         <updated>2022-03-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America adds to its track record of industry-first breakthroughs in powertrain innovation with the Volvo I-Torque.]]></content>
         <published>2022-03-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces 2021 U.S. Dealer Group of the Year Award Winners]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-announces-2021-us-dealer-group-of-the-year-award-winners/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-announces-2021-us-dealer-group-of-the-year-award-winners/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-announces-2021-us-dealer-group-of-the-year-award-winners/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-announces-2021-us-dealer-group-of-the-year-award-winners/"/>
         <updated>2022-03-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America named New York-based Milea Truck Sales and Leasing as its 2021 U.S. Dealer Group of the Year. The annual award recognizes exemplary performance across several key areas, including reaching sales targets, business growth, and customer satisfaction.]]></content>
         <published>2022-03-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Route Planning and Connected Technology Tools introduced to Support Customers in Scaling Electromobility Solutions | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/route-planning-and-connected-technology-tools-to-support-customers-in-electromobility-solutions/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/route-planning-and-connected-technology-tools-to-support-customers-in-electromobility-solutions/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/route-planning-and-connected-technology-tools-to-support-customers-in-electromobility-solutions/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/route-planning-and-connected-technology-tools-to-support-customers-in-electromobility-solutions/"/>
         <updated>2022-03-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is introducing two new innovative technology tools to support customers in successfully deploying Volvo VNR Electric Class 8 models into their fleet operations.]]></content>
         <published>2022-03-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Offer Customers New Advanced Roadside Assistance Service Tracking Feature]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-to-offer-customers-new-advanced-roadside-assistance-service-tracking-feature/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-to-offer-customers-new-advanced-roadside-assistance-service-tracking-feature/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-to-offer-customers-new-advanced-roadside-assistance-service-tracking-feature/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-to-offer-customers-new-advanced-roadside-assistance-service-tracking-feature/"/>
         <updated>2022-03-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced the launch of an all-new service tracking feature to its Volvo Action Service roadside assistance program at the American Trucking Association’s Technology and Maintenance Council (TMC) event this week. The innovative service tracker will enhance the customer experience during an unplanned stop through a digital, user-friendly platform.]]></content>
         <published>2022-03-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit Best-in-Class Powertrain and Electromobility Solutions at TMC]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-to-exhibit-best-in-class-powertrain-and-electromobility-solutions-at-tmc/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/march/volvo-trucks-to-exhibit-best-in-class-powertrain-and-electromobility-solutions-at-tmc/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-to-exhibit-best-in-class-powertrain-and-electromobility-solutions-at-tmc/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/march/volvo-trucks-to-exhibit-best-in-class-powertrain-and-electromobility-solutions-at-tmc/"/>
         <updated>2022-03-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will showcase the Volvo VNR Electric 4x2 tractor and Volvo VNL 760 model in its booth #1005 at the American Trucking Associations’ Technology & Maintenance Council (TMC) 2022 Spring Meeting March 7-10 in the Orange County Convention Center in Orlando, Florida.]]></content>
         <published>2022-03-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces First Two Volvo Trucks Certified EV Dealers in Canada]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/february/volvo-trucks-announces-first-two-volvo-trucks-certified-ev-dealers-in-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/february/volvo-trucks-announces-first-two-volvo-trucks-certified-ev-dealers-in-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/february/volvo-trucks-announces-first-two-volvo-trucks-certified-ev-dealers-in-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/february/volvo-trucks-announces-first-two-volvo-trucks-certified-ev-dealers-in-canada/"/>
         <updated>2022-02-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has designated two dealerships in Québec, as the first two Volvo Trucks Certified Electric Vehicle (EV) Dealers in Canada.]]></content>
         <published>2022-02-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Nacarato Truck Centers Becomes First Volvo Trucks Certified Electric Vehicle Dealer in Virginia]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/nacarato-truck-centers-becomes-first-volvo-trucks-certified-electric-vehicle-dealer-in-virginia/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/nacarato-truck-centers-becomes-first-volvo-trucks-certified-electric-vehicle-dealer-in-virginia/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/nacarato-truck-centers-becomes-first-volvo-trucks-certified-electric-vehicle-dealer-in-virginia/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/nacarato-truck-centers-becomes-first-volvo-trucks-certified-electric-vehicle-dealer-in-virginia/"/>
         <updated>2022-01-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has expanded its network of Certified Electric Vehicle (EV) Dealers into Virginia, announcing that Nacarato Truck Centers’ Roanoke dealership has completed the required training and certification program. Nacarato Truck Centers has been instrumental in introducing Volvo Trucks’ VNR Electric model in the state]]></content>
         <published>2022-01-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Groupe Morneau Deploys First Volvo VNR Electric in Quebec City | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/groupe-morneau-deploys-first-volvo-vnr-electric-in-quebec-city/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/groupe-morneau-deploys-first-volvo-vnr-electric-in-quebec-city/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/groupe-morneau-deploys-first-volvo-vnr-electric-in-quebec-city/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/groupe-morneau-deploys-first-volvo-vnr-electric-in-quebec-city/"/>
         <updated>2022-01-27T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America’s customer Groupe Morneau took delivery of its first Volvo VNR Electric to operate on freight logistics routes in eastern Canada. The zero-tailpipe emission Class 8 truck was delivered to Groupe Morneau this week during a key handover event with the local Volvo Trucks dealership, Paré Centre du Camion.]]></content>
         <published>2022-01-27T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Applauds 2022-2023 America’s Road Team Captains]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/volvo-trucks-applauds-2022-2023-america-s-road-team-captains/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/volvo-trucks-applauds-2022-2023-america-s-road-team-captains/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/volvo-trucks-applauds-2022-2023-america-s-road-team-captains/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/volvo-trucks-applauds-2022-2023-america-s-road-team-captains/"/>
         <updated>2022-01-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks celebrated the American Trucking Associations’ (ATA) new trucking ambassadors at the association’s headquarters in Arlington, Va., last week including delivery of a VNL 760 long-haul tractor. The newly appointed America’s Road Team Captains will use the VNL 760 to haul the ATA Interstate One mobile classroom for their nationwide education program.]]></content>
         <published>2022-01-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Affinity Truck Center Becomes First Volvo Trucks Certified EV Dealer in Californias Central Valley]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/affinity-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-californias-central-valley/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/affinity-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-californias-central-valley/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/affinity-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-californias-central-valley/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/affinity-truck-center-becomes-first-volvo-trucks-certified-ev-dealer-in-californias-central-valley/"/>
         <updated>2022-01-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has designated Affinity Truck Center’s Fresno, California, location as a Volvo Trucks Certified Electric Vehicle (EV) Dealer, signifying that it is ready to support customers interested in adding Volvo VNR Electrics to their local and regional distribution, pickup and delivery, and food and beverage distribution routes.]]></content>
         <published>2022-01-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces Next Generation VNR Electric with Enhanced Range and Additional Config | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/volvo-trucks-announces-next-generation-vnr-electric-with-enhanced-range-and-additional-config/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2022/january/volvo-trucks-announces-next-generation-vnr-electric-with-enhanced-range-and-additional-config/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/volvo-trucks-announces-next-generation-vnr-electric-with-enhanced-range-and-additional-config/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2022/january/volvo-trucks-announces-next-generation-vnr-electric-with-enhanced-range-and-additional-config/"/>
         <updated>2022-01-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America continues to lead in the deployment of sustainable Class 8 zero-tailpipe emission vehicles for the North American trucking industry with ongoing deliveries of its Volvo VNR Electric model to fleets across the country.]]></content>
         <published>2022-01-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[TEC Equipment La Mirada Earns Volvo Trucks EV Certified Dealership Designation]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/december/tec-equipment-la-mirada-earns-volvo-trucks-ev-certified-dealership-designation/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/december/tec-equipment-la-mirada-earns-volvo-trucks-ev-certified-dealership-designation/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/december/tec-equipment-la-mirada-earns-volvo-trucks-ev-certified-dealership-designation/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/december/tec-equipment-la-mirada-earns-volvo-trucks-ev-certified-dealership-designation/"/>
         <updated>2021-12-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ largest West Coast dealership, TEC Equipment, continues to support trucking fleets with their electromobility transition as its La Mirada branch in Southern California becomes its second location to achieve the Volvo Trucks Electric Vehicle (EV) Certified Dealer designation.]]></content>
         <published>2021-12-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Dealer Group Vanguard Expands National Footprint with Acquisition of Advantage Truck Centers]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/november/volvo-trucks-dealer-group-vanguard-expands-national-footprint/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/november/volvo-trucks-dealer-group-vanguard-expands-national-footprint/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/november/volvo-trucks-dealer-group-vanguard-expands-national-footprint/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/november/volvo-trucks-dealer-group-vanguard-expands-national-footprint/"/>
         <updated>2021-11-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announces Vanguard Truck Centers, a multi-regional, full-service commercial truck dealer group and leasing operation, has acquired Charlotte-based Advantage Truck Centers and Advantage Truck Leasing.]]></content>
         <published>2021-11-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Extends Exclusive Sponsorship of America s Road Team for 2022]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2022/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2022/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2022/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-extends-exclusive-sponsorship-of-america-s-road-team-for-2022/"/>
         <updated>2021-10-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will enter its 20th consecutive year as the exclusive sponsor of the America’s Road Team public outreach program in 2022.]]></content>
         <published>2021-10-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Two Virginia Fleets Commit to Operating Zero Tailpipe Emission Volvo VNR Electrics | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/two-virginia-fleets-commit-to-operating-zero-tailpipe-emission-volvo-vnr-electrics/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/two-virginia-fleets-commit-to-operating-zero-tailpipe-emission-volvo-vnr-electrics/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/two-virginia-fleets-commit-to-operating-zero-tailpipe-emission-volvo-vnr-electrics/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/two-virginia-fleets-commit-to-operating-zero-tailpipe-emission-volvo-vnr-electrics/"/>
         <updated>2021-10-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America’s customers and carrier partners, Watsontown Trucking Company and Camrett Logistics, have placed orders for their first Volvo VNR Electric trucks.]]></content>
         <published>2021-10-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Showcase VNR Electric 25th Anniversary VNL 760 and VN Model at ATA MC E]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-to-showcase-vnr-electric-25th-anniversary-vnl-760-and-vn-model-at-ata-mc-e/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-to-showcase-vnr-electric-25th-anniversary-vnl-760-and-vn-model-at-ata-mc-e/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-to-showcase-vnr-electric-25th-anniversary-vnl-760-and-vn-model-at-ata-mc-e/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-to-showcase-vnr-electric-25th-anniversary-vnl-760-and-vn-model-at-ata-mc-e/"/>
         <updated>2021-10-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will feature the VNR Electric, the 25th anniversary VNL 760 and an original Volvo VN truck from 1996 in its booth (No. 8131) at the American Trucking Associations’ (ATA) 2021 Management Conference & Exhibition (MC&E) Oct. 23-26 in Nashville, Tennessee.]]></content>
         <published>2021-10-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Producers Dairy Orders First Volvo VNR Electric Trucks]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-customer-producers-dairy-orders-first-volvo-vnr-electric-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-customer-producers-dairy-orders-first-volvo-vnr-electric-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-customer-producers-dairy-orders-first-volvo-vnr-electric-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-customer-producers-dairy-orders-first-volvo-vnr-electric-trucks/"/>
         <updated>2021-10-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Producers Dairy, a Central California-based dairy processor and direct-to-store supplier, has placed an order for two Volvo VNR Electric trucks anticipated to be the first commercial battery-electric Class 8 trucks to be deployed in California’s Central Valley.]]></content>
         <published>2021-10-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo LIGHTS Project Team Wins 2021 Climate Leadership Award for Innovative Partnership | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-lights-project-team-wins-2021-climate-leadership-award-for-innovative-partnership/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-lights-project-team-wins-2021-climate-leadership-award-for-innovative-partnership/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-lights-project-team-wins-2021-climate-leadership-award-for-innovative-partnership/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-lights-project-team-wins-2021-climate-leadership-award-for-innovative-partnership/"/>
         <updated>2021-10-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today accepted a 2021 Climate Leadership Award for the Volvo LIGHTS (Low Impact Green Heavy Transport Solutions) project in Southern California.]]></content>
         <published>2021-10-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks D13 Turbo Compound Engine on All VNL Models | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-d13-turbo-compound-engine-on-all-vnl-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/october/volvo-trucks-d13-turbo-compound-engine-on-all-vnl-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-d13-turbo-compound-engine-on-all-vnl-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/october/volvo-trucks-d13-turbo-compound-engine-on-all-vnl-models/"/>
         <updated>2021-10-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The enhanced D13 Turbo Compound (D13TC) engine from Volvo Trucks is now standard on all Volvo VNL models, providing enhanced fuel efficiency and reducing overall cost of ownership.]]></content>
         <published>2021-10-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Experience Center Offers Fleets Full Electromobility Experience]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-customer-experience-center-offers-fleets-full-electromobility-experience/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-customer-experience-center-offers-fleets-full-electromobility-experience/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-customer-experience-center-offers-fleets-full-electromobility-experience/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-customer-experience-center-offers-fleets-full-electromobility-experience/"/>
         <updated>2021-09-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America recently celebrated the opening of its new electromobility showcase at its Customer Experience Center in Dublin, Virginia.]]></content>
         <published>2021-09-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Adds Electric Fleet Charging Startup | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-adds-electric-fleet-charging-startup/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-adds-electric-fleet-charging-startup/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-adds-electric-fleet-charging-startup/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-adds-electric-fleet-charging-startup/"/>
         <updated>2021-09-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is building a community of innovators that are designing solutions to support the global transition to more sustainable transport systems. The Innovation Lab at Volvo Group, located in the heart of Silicon Valley, is a place where Volvo Trucks can collaborate with start-ups to combine real-world insights, analyze emerging trends, and validate new products and services aimed at helping customers improve both their economic and environmental sustainability goals.]]></content>
         <published>2021-09-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit VNR Electric and 25th Anniversary VNL 760 at ExpoCam]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-vnr-electric-and-25th-anniversary-vnl-760-at-expocam/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-vnr-electric-and-25th-anniversary-vnl-760-at-expocam/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-vnr-electric-and-25th-anniversary-vnl-760-at-expocam/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-vnr-electric-and-25th-anniversary-vnl-760-at-expocam/"/>
         <updated>2021-09-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will showcase the VNR Electric, 25th anniversary VNL 760, VNL 860 and VHD model in its booth (No. 1029) at ExpoCam Sept. 22-23 outside of Montreal, Canada.]]></content>
         <published>2021-09-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit the Latest in Powertrain and Electromobility Offerings at TMC]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-the-latest-in-powertrain-and-electromobility-offerings-at-tmc/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-the-latest-in-powertrain-and-electromobility-offerings-at-tmc/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-the-latest-in-powertrain-and-electromobility-offerings-at-tmc/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-to-exhibit-the-latest-in-powertrain-and-electromobility-offerings-at-tmc/"/>
         <updated>2021-09-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will showcase the VNR Electric and 25th anniversary Volvo VNL 760 model in its booth #8045 at the American Trucking Associations’ Technology & Maintenance Council (TMC) 2021 Fall Meeting Sept.]]></content>
         <published>2021-09-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Dealer Nextran Truck Centers Enhances US Footprint with Westfall O Dell Acquisition]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-dealer-nextran-truck-centers-enhances-us-footprint-with-westfall-o-dell-acquisition/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/september/volvo-trucks-dealer-nextran-truck-centers-enhances-us-footprint-with-westfall-o-dell-acquisition/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-dealer-nextran-truck-centers-enhances-us-footprint-with-westfall-o-dell-acquisition/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/september/volvo-trucks-dealer-nextran-truck-centers-enhances-us-footprint-with-westfall-o-dell-acquisition/"/>
         <updated>2021-09-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced that established Volvo Trucks dealer Nextran Truck Centers has acquired Westfall-O’Dell Truck Sales. The acquisition is one of the largest by a Volvo Trucks dealer in the past five years.]]></content>
         <published>2021-09-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer A Maersk Company Places Largest Order of VNR Electric Models]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-customer-a-maersk-company-places-largest-order-of-vnr-electric-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-customer-a-maersk-company-places-largest-order-of-vnr-electric-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-customer-a-maersk-company-places-largest-order-of-vnr-electric-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-customer-a-maersk-company-places-largest-order-of-vnr-electric-models/"/>
         <updated>2021-08-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Performance Team – A Maersk Company, a warehousing and distribution company, has placed an order for 16 Volvo VNR Electric Class 8 trucks—the largest commercial order of the North American zero-tailpipe emission model to date.]]></content>
         <published>2021-08-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks VNR Electric Will Deliver Zero-Tailpipe Emissions Transportation to New River Valley]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-vnr-electric-will-deliver-zero-tailpipe-emissions-transportation-to-new-river-valley/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-vnr-electric-will-deliver-zero-tailpipe-emissions-transportation-to-new-river-valley/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-vnr-electric-will-deliver-zero-tailpipe-emissions-transportation-to-new-river-valley/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-vnr-electric-will-deliver-zero-tailpipe-emissions-transportation-to-new-river-valley/"/>
         <updated>2021-08-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo VNR Electric, Volvo Trucks North America’s first commercially available battery-electric Class 8 vehicle, will be deployed on local logistics routes servicing the company’s New River Valley (NRV) truck assembly operations in Dublin, Virginia by end the end of 2021.]]></content>
         <published>2021-08-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Dependable Highway Express to Transport SunPower Products Using VNR Electric]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-customer-dependable-highway-express-to-transport-sunpower-products-using-vnr-electric/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-customer-dependable-highway-express-to-transport-sunpower-products-using-vnr-electric/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-customer-dependable-highway-express-to-transport-sunpower-products-using-vnr-electric/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-customer-dependable-highway-express-to-transport-sunpower-products-using-vnr-electric/"/>
         <updated>2021-08-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America, Dependable Highway Express (DHE), SunPower Corp. and Kuehne+Nagel today announced a new sustainable freight initiative to transport solar photovoltaics (PV) products using solar-powered Volvo VNR Electric trucks.]]></content>
         <published>2021-08-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks NFI Team Up for Run on Less Electric Showcase]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-nfi-team-up-for-run-on-less-electric-showcase/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-nfi-team-up-for-run-on-less-electric-showcase/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-nfi-team-up-for-run-on-less-electric-showcase/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-nfi-team-up-for-run-on-less-electric-showcase/"/>
         <updated>2021-08-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America, along with third-party supply chain solutions provider NFI, is participating in Run on Less – Electric (RoL-E), an electric truck technology demonstration that showcases advancements in freight efficiency.]]></content>
         <published>2021-08-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Delivers the First of Five VNR Electrics to Manhattan Beer Distributors]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-delivers-the-first-of-five-vnr-electrics-to-manhattan-beer-distributors/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-delivers-the-first-of-five-vnr-electrics-to-manhattan-beer-distributors/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-delivers-the-first-of-five-vnr-electrics-to-manhattan-beer-distributors/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-delivers-the-first-of-five-vnr-electrics-to-manhattan-beer-distributors/"/>
         <updated>2021-08-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today delivered its first Class 8, battery-electric regional hauling truck on the East Coast to its customer Manhattan Beer Distributors.]]></content>
         <published>2021-08-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces First East Coast Volvo EV Certified Dealer Milea Truck Sales and Leasing]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-announces-first-east-coast-volvo-ev-certified-dealer-milea-truck-sales-and-leasing/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/august/volvo-trucks-announces-first-east-coast-volvo-ev-certified-dealer-milea-truck-sales-and-leasing/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-announces-first-east-coast-volvo-ev-certified-dealer-milea-truck-sales-and-leasing/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/august/volvo-trucks-announces-first-east-coast-volvo-ev-certified-dealer-milea-truck-sales-and-leasing/"/>
         <updated>2021-08-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Milea Truck Sales and Leasing, serving New York City and the tri-state area, is the second Volvo Trucks North America dealership and the first on the East Coast to become a Volvo EV Certified Dealer. With this certification, Milea’s sales team is, together with the VTNA electromobility team, fully trained to consult with customers in the transition towards Class 8 electric trucks, evaluate which of their routes are the most ideal for electromobility.]]></content>
         <published>2021-08-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names TEC Equipment Fontana as First Volvo EV Certified Dealer]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-names-tec-equipment-fontana-as-first-volvo-ev-certified-dealer/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-names-tec-equipment-fontana-as-first-volvo-ev-certified-dealer/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-names-tec-equipment-fontana-as-first-volvo-ev-certified-dealer/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-names-tec-equipment-fontana-as-first-volvo-ev-certified-dealer/"/>
         <updated>2021-07-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ largest West Coast dealership, TEC Equipment, has been named the company’s first Volvo EV Certified Dealer in North America.]]></content>
         <published>2021-07-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces Volvo Blue Contract Service Offering to Enhance Uptime]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-introduces-volvo-blue-contract-service-offering-to-enhance-uptime/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-introduces-volvo-blue-contract-service-offering-to-enhance-uptime/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-introduces-volvo-blue-contract-service-offering-to-enhance-uptime/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-introduces-volvo-blue-contract-service-offering-to-enhance-uptime/"/>
         <updated>2021-07-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has introduced the Volvo Blue Contract service offering, a comprehensive maintenance program designed to improve uptime, assist in optimizing truck performance and simplify maintenance management for customers and dealers.]]></content>
         <published>2021-07-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America and UAW Agree on Six-Year Contract | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-north-america-and-uaw-agree-on-six-year-contract/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-north-america-and-uaw-agree-on-six-year-contract/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-north-america-and-uaw-agree-on-six-year-contract/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-north-america-and-uaw-agree-on-six-year-contract/"/>
         <updated>2021-07-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today announced that employees represented by the United Auto Workers union (UAW) have ratified a new six-year agreement covering about 2,900 members of UAW Local #2069 at the New River Valley truck assembly operations (NRV) in Dublin, Virginia.]]></content>
         <published>2021-07-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Re-Start Production at NRV Plant | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-to-re-start-production-at-nrv-plant/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/july/volvo-trucks-to-re-start-production-at-nrv-plant/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-to-re-start-production-at-nrv-plant/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/july/volvo-trucks-to-re-start-production-at-nrv-plant/"/>
         <updated>2021-07-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[After reaching an impasse today in discussions with United Auto Workers (UAW) negotiators regarding a new contract for the company’s New River Valley (NRV) plant, Volvo Trucks North America will on July 12, 2021 implement the terms and conditions of the tentative agreement endorsed by UAW leaders on July 1, 2021.]]></content>
         <published>2021-07-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Partners with Bendix to Help Boost Driver Safety and Training]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-partners-with-bendix-to-help-boost-driver-safety-and-training/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-partners-with-bendix-to-help-boost-driver-safety-and-training/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-partners-with-bendix-to-help-boost-driver-safety-and-training/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-partners-with-bendix-to-help-boost-driver-safety-and-training/"/>
         <updated>2021-06-30T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is offering the fifth generation of the SafetyDirect® Processor (SDP5™ Full) from Bendix Commercial Vehicle Systems as a factory-installed option on Volvo VNL, VNR and VHD models.]]></content>
         <published>2021-06-30T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Showcase VNR Electric and 25th Anniversary VNL 760 at NPTC Conference]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-to-showcase-vnr-electric-and-25th-anniversary-vnl-760-at-nptc-conference/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-to-showcase-vnr-electric-and-25th-anniversary-vnl-760-at-nptc-conference/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-to-showcase-vnr-electric-and-25th-anniversary-vnl-760-at-nptc-conference/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-to-showcase-vnr-electric-and-25th-anniversary-vnl-760-at-nptc-conference/"/>
         <updated>2021-06-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will display the latest Volvo VNL 760 and VNR Electric model, including the next-generation D13 Turbo Compound (D13TC) engine and Volvo I-Shift transmission, in its booth (No. 612) at the National Private Truck Council (NPTC) 2021 Annual Education Management Conference and Exhibition. The event takes place June 13-15, 2021 in Cincinnati, Ohio.]]></content>
         <published>2021-06-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Manhattan Beer Distributors Orders Five VNR Electric Models]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-customer-manhattan-beer-distributors-orders-five-vnr-electric-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-customer-manhattan-beer-distributors-orders-five-vnr-electric-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-customer-manhattan-beer-distributors-orders-five-vnr-electric-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-customer-manhattan-beer-distributors-orders-five-vnr-electric-models/"/>
         <updated>2021-06-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Manhattan Beer Distributors, a major New York City-based beer and beverage distributor, has placed an order for five Volvo VNR Electric Class 8 trucks — the first zero tailpipe emission, battery-electric trucks to be deployed in Manhattan Beer Distributors’ fleet of more than 400 delivery trucks.]]></content>
         <published>2021-06-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Provides Penske Truck Leasing with VNR Electric Models in Southern California]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-provides-penske-truck-leasing-with-vnr-electric-models-in-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/june/volvo-trucks-provides-penske-truck-leasing-with-vnr-electric-models-in-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-provides-penske-truck-leasing-with-vnr-electric-models-in-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/june/volvo-trucks-provides-penske-truck-leasing-with-vnr-electric-models-in-southern-california/"/>
         <updated>2021-06-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Penske Truck Leasing recently took delivery of two VNR Electrics from Volvo Trucks North America, expanding its fleet of battery-electric Class 8 models available in Southern California.]]></content>
         <published>2021-06-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Customer Albertsons Achieves Nation s First Commercial Zero-Emission Refrigerated Grocery Delivery | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/customer-albertsons-achieves-nation-s-first-commercial-zero-emission-refrigerated-grocery-delivery/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/customer-albertsons-achieves-nation-s-first-commercial-zero-emission-refrigerated-grocery-delivery/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/customer-albertsons-achieves-nation-s-first-commercial-zero-emission-refrigerated-grocery-delivery/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/customer-albertsons-achieves-nation-s-first-commercial-zero-emission-refrigerated-grocery-delivery/"/>
         <updated>2021-05-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Albertsons Companies, the second-largest grocery chain in the U.S., recently took delivery of two Volvo VNR Electric trucks at its distribution center in Irvine, California. The VNR Electric models from Volvo Trucks North America are the first zero tailpipe emission, battery-electric Class 8 trucks to be deployed in Albertsons Cos.]]></content>
         <published>2021-05-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks I-Shift Transmission Technology Still Leading Innovation in North America]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/volvo-trucks-i-shift-transmission-technology-still-leading-innovation-in-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/volvo-trucks-i-shift-transmission-technology-still-leading-innovation-in-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/volvo-trucks-i-shift-transmission-technology-still-leading-innovation-in-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/volvo-trucks-i-shift-transmission-technology-still-leading-innovation-in-north-america/"/>
         <updated>2021-05-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ revolutionary I-Shift intelligent automated manual transmission celebrates 15 years in North America in 2021, and continues to set industry benchmarks for fuel efficiency, vehicle performance, safety and driver comfort.]]></content>
         <published>2021-05-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks and Lytx Partner to Boost Safety and Performance with State-of-the-Art Video Telematics]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/volvo-trucks-and-lytx-partner-to-boost-safety-and-performance-with-state-of-the-art-video-telematics/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/may/volvo-trucks-and-lytx-partner-to-boost-safety-and-performance-with-state-of-the-art-video-telematics/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/volvo-trucks-and-lytx-partner-to-boost-safety-and-performance-with-state-of-the-art-video-telematics/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/may/volvo-trucks-and-lytx-partner-to-boost-safety-and-performance-with-state-of-the-art-video-telematics/"/>
         <updated>2021-05-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Onboard technology from Lytx®, a leading provider of machine vision and artificial intelligence-powered video telematics, is now available on all model-year 2022 or newer Volvo trucks as a factory-installed option. The integration of this technology reinforces Volvo Trucks’ vision Towards Zero Accidents and commitment to offering the latest safety features for its customers.]]></content>
         <published>2021-05-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Customer Saia Takes Delivery of Two Volvo VNR Electrics]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/volvo-trucks-customer-saia-takes-delivery-of-two-volvo-vnr-electrics/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/volvo-trucks-customer-saia-takes-delivery-of-two-volvo-vnr-electrics/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/volvo-trucks-customer-saia-takes-delivery-of-two-volvo-vnr-electrics/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/volvo-trucks-customer-saia-takes-delivery-of-two-volvo-vnr-electrics/"/>
         <updated>2021-04-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Saia LTL Freight, a leading national transportation and logistics provider founded in 1924, recently took delivery of two Volvo VNR Electric trucks at its facility in Los Angeles, California.]]></content>
         <published>2021-04-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Opens New Training Facility in California]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/volvo-trucks-opens-new-training-facility-in-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/volvo-trucks-opens-new-training-facility-in-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/volvo-trucks-opens-new-training-facility-in-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/volvo-trucks-opens-new-training-facility-in-california/"/>
         <updated>2021-04-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks expands its North American training footprint with the addition of a 9,600-square-foot location in Hayward, California, conveniently located near San Francisco. It is scheduled to open June 1.]]></content>
         <published>2021-04-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Quality Custom Distribution Largest Commercial VNR Electric Order to Date | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/quality-custom-distribution-largest-commercial-vnr-electric-order-to-date/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/quality-custom-distribution-largest-commercial-vnr-electric-order-to-date/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/quality-custom-distribution-largest-commercial-vnr-electric-order-to-date/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/quality-custom-distribution-largest-commercial-vnr-electric-order-to-date/"/>
         <updated>2021-04-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Large Order of Volvo VNR Electric Trucks]]></content>
         <published>2021-04-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Last-Mile Delivery Fleet Quality Custom Distribution Takes Delivery of VNR Electric | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/last-mile-delivery-fleet-quality-custom-distribution-takes-delivery-of-volvo-vnr-electric/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/april/last-mile-delivery-fleet-quality-custom-distribution-takes-delivery-of-volvo-vnr-electric/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/last-mile-delivery-fleet-quality-custom-distribution-takes-delivery-of-volvo-vnr-electric/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/april/last-mile-delivery-fleet-quality-custom-distribution-takes-delivery-of-volvo-vnr-electric/"/>
         <updated>2021-04-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Quality Custom Distribution (QCD), a national food service logistics provider, recently took delivery of a Volvo VNR Electric—the first zero-emission, battery-electric truck to be deployed in QCD’s fleet of more than 700 vehicles.]]></content>
         <published>2021-04-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Celebrates 25 Years of Setting Industry Standards with Iconic VNL Model]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-celebrates-25-years-of-setting-industry-standards-with-iconic-vnl-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-celebrates-25-years-of-setting-industry-standards-with-iconic-vnl-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-celebrates-25-years-of-setting-industry-standards-with-iconic-vnl-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-celebrates-25-years-of-setting-industry-standards-with-iconic-vnl-model/"/>
         <updated>2021-03-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The 25th anniversary of the Volvo VNL marks over a quarter century of definitive innovation from Volvo Trucks North America, raising standards of design, efficiency, performance and safety that have served as a road map for the heavy-duty trucking industry.]]></content>
         <published>2021-03-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo VNR Electric Now Eligible for Vehicle Funding and Incentives Across North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-vnr-electric-now-eligible-for-vehicle-funding-and-incentives-across-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-vnr-electric-now-eligible-for-vehicle-funding-and-incentives-across-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-vnr-electric-now-eligible-for-vehicle-funding-and-incentives-across-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-vnr-electric-now-eligible-for-vehicle-funding-and-incentives-across-north-america/"/>
         <updated>2021-03-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo VNR Electric, Volvo Trucks North America’s first commercially available battery-electric Class 8 vehicle, is now eligible for dozens of funding and incentive programs across North America, including up to $120,000 per vehicle from California’s Hybrid and Zero-Emission Truck and Bus Voucher Incentive Project (HVIP).]]></content>
         <published>2021-03-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Selects Hickman Truck Centre as 2020 Canada Dealer Group of the Year]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-selects-hickman-truck-centre-as-2020-canada-dealer-group-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-selects-hickman-truck-centre-as-2020-canada-dealer-group-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-selects-hickman-truck-centre-as-2020-canada-dealer-group-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-selects-hickman-truck-centre-as-2020-canada-dealer-group-of-the-year/"/>
         <updated>2021-03-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America named Hickman Truck Centre, located in St. John’s, Newfoundland and Labrador, as its 2020 Canada Dealer Group of the Year. The company was honored along with other top regional Volvo Trucks dealership groups during a recent virtual awards ceremony.]]></content>
         <published>2021-03-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces 2020 North America Dealer Group of the Year Award Winners]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-announces-2020-north-america-dealer-group-of-the-year-award-winners/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/volvo-trucks-announces-2020-north-america-dealer-group-of-the-year-award-winners/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-announces-2020-north-america-dealer-group-of-the-year-award-winners/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/volvo-trucks-announces-2020-north-america-dealer-group-of-the-year-award-winners/"/>
         <updated>2021-03-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America named North Carolina-based Advantage Truck Center as its 2020 North America Dealer Group of the Year. The company also honored its top regional dealership groups during a recent virtual awards ceremony.]]></content>
         <published>2021-03-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Unlimited Parameter Updates Now Available to Customers Through Volvo Trucks’ Remote Programming Service]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/unlimited-parameter-updates-now-available-to-customers-through-volvo-trucks-remote-programming/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/unlimited-parameter-updates-now-available-to-customers-through-volvo-trucks-remote-programming/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/unlimited-parameter-updates-now-available-to-customers-through-volvo-trucks-remote-programming/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/unlimited-parameter-updates-now-available-to-customers-through-volvo-trucks-remote-programming/"/>
         <updated>2021-03-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[With access to all Volvo Trucks parameter updates, customers can now optimize their vehicles’ operations without limitations. Parameter updates can be completed from virtually anywhere, enabling Volvo Trucks North America customers and their drivers to boost their uptime, efficiency and productivity.]]></content>
         <published>2021-03-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ Customer NFI Leading the Charge Toward Freight Transportation Electrification in Southern California]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/customer-nfi-leading-the-charge-toward-freight-transportation-electrification-in-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/march/customer-nfi-leading-the-charge-toward-freight-transportation-electrification-in-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/customer-nfi-leading-the-charge-toward-freight-transportation-electrification-in-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/march/customer-nfi-leading-the-charge-toward-freight-transportation-electrification-in-southern-california/"/>
         <updated>2021-03-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[NFI, one of the nation’s oldest and largest third-party supply chain solutions providers, recently reached a major sustainability milestone by completing several key electrification initiatives.]]></content>
         <published>2021-03-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Vanguard Truck Centers Opens New Flagship Volvo Trucks Dealership in Houston]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/february/vanguard-truck-centers-opens-new-flagship-volvo-trucks-dealership-in-houston/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/february/vanguard-truck-centers-opens-new-flagship-volvo-trucks-dealership-in-houston/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/february/vanguard-truck-centers-opens-new-flagship-volvo-trucks-dealership-in-houston/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/february/vanguard-truck-centers-opens-new-flagship-volvo-trucks-dealership-in-houston/"/>
         <updated>2021-02-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer Vanguard Truck Centers has invested $23 million in a new facility, which is one of four locations in the Houston, Texas area, in addition to a full-service body shop, offering customers increased uptime, service and support.]]></content>
         <published>2021-02-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Offers Integrated Insurance to Customers in Select U.S. Markets]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/february/volvo-trucks-offers-integrated-insurance-to-customers-in-select-us-markets/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/february/volvo-trucks-offers-integrated-insurance-to-customers-in-select-us-markets/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/february/volvo-trucks-offers-integrated-insurance-to-customers-in-select-us-markets/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/february/volvo-trucks-offers-integrated-insurance-to-customers-in-select-us-markets/"/>
         <updated>2021-02-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Financial Services (VFS) is working with leading insurtech company REIN to pilot an integrated digital insurance offering. The service’s enhanced capabilities will soon allow Volvo Trucks North America customers to connect in real time with insurance companies for a more seamless experience.]]></content>
         <published>2021-02-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Offers Customers Enhanced Speed and Efficiency with New E-Commerce Platform PartsASIST]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/volvo-trucks-offers-customers-enhanced-speed-and-efficiency-with-new-e-commerce-platform-partsasist/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/volvo-trucks-offers-customers-enhanced-speed-and-efficiency-with-new-e-commerce-platform-partsasist/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/volvo-trucks-offers-customers-enhanced-speed-and-efficiency-with-new-e-commerce-platform-partsasist/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/volvo-trucks-offers-customers-enhanced-speed-and-efficiency-with-new-e-commerce-platform-partsasist/"/>
         <updated>2021-01-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[With secure, remote access to parts, components and expert support, PartsASIST is a complete, one-stop online solution that increases uptime by enabling faster, simpler and more efficient service.]]></content>
         <published>2021-01-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Conway Beam Truck Group Opens New Volvo Trucks Dealer Facility Near Buffalo]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/conway-beam-truck-group-opens-new-volvo-trucks-dealer-facility-near-buffalo/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/conway-beam-truck-group-opens-new-volvo-trucks-dealer-facility-near-buffalo/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/conway-beam-truck-group-opens-new-volvo-trucks-dealer-facility-near-buffalo/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/conway-beam-truck-group-opens-new-volvo-trucks-dealer-facility-near-buffalo/"/>
         <updated>2021-01-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealership Conway Beam Truck Group invested $16.2 million to expand its presence in western New York with the opening of a new 75,000 square-foot location in West Seneca.]]></content>
         <published>2021-01-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Customer Dependable Highway Express Reduces Carbon Footprint by Electrifying | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/customer-dependable-highway-express-reduces-carbon-footprint-by-electrifying/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2021/january/customer-dependable-highway-express-reduces-carbon-footprint-by-electrifying/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/customer-dependable-highway-express-reduces-carbon-footprint-by-electrifying/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2021/january/customer-dependable-highway-express-reduces-carbon-footprint-by-electrifying/"/>
         <updated>2021-01-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Leading freight operator, Dependable Highway Express (DHE), recently completed several major electrification initiatives to further reduce the climate and air quality impacts of its Southern California freight operations.]]></content>
         <published>2021-01-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Driver Display Activation Remote Programming Feature Now Standard on All Volvo Trucks]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/driver-display-activation-remote-programming-feature-now-standard-on-all-volvo-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/driver-display-activation-remote-programming-feature-now-standard-on-all-volvo-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/driver-display-activation-remote-programming-feature-now-standard-on-all-volvo-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/driver-display-activation-remote-programming-feature-now-standard-on-all-volvo-trucks/"/>
         <updated>2020-12-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[After a successful four-month pilot program, Volvo Trucks’ Driver Display Activation (DDA) application went into full production on Nov. 30, 2020. The new enhancement to Remote Programming, as part of Volvo Trucks’ Remote Diagnostics bundle of Uptime Services, now allows operators to directly activate over-the-air system updates within minutes at the next convenient time and location – whether that is at their next rest stop or back at the shop.]]></content>
         <published>2020-12-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Gold Contract Service Offering Standard with the New Volvo VNR Electric Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-gold-contract-service-offering-standard-with-the-new-volvo-vnr-electric-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-gold-contract-service-offering-standard-with-the-new-volvo-vnr-electric-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-gold-contract-service-offering-standard-with-the-new-volvo-vnr-electric-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-gold-contract-service-offering-standard-with-the-new-volvo-vnr-electric-model/"/>
         <updated>2020-12-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has full confidence in the Volvo VNR Electric and is committed to making the transition to electric truck ownership smooth and seamless for its customers by offering special financing and insurance solutions through Volvo Financial Services (VFS), service and support bundles available for ease of ownership throughout the life cycle of the new truck model.]]></content>
         <published>2020-12-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Leads Electrification of North American Trucking Industry]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-trucks-leads-electrification-of-north-american-trucking-industry/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-trucks-leads-electrification-of-north-american-trucking-industry/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-trucks-leads-electrification-of-north-american-trucking-industry/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-trucks-leads-electrification-of-north-american-trucking-industry/"/>
         <updated>2020-12-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[With the sales start of Volvo Trucks North America’s Class 8 zero tailpipe emission VNR Electric truck model in the U.S. and Canada, the company continues to drive electromobility forward.]]></content>
         <published>2020-12-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces the Volvo VNR Electric Model in the U.S., Canada]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-trucks-introduces-the-volvo-vnr-electric-model-in-the-us-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/december/volvo-trucks-introduces-the-volvo-vnr-electric-model-in-the-us-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-trucks-introduces-the-volvo-vnr-electric-model-in-the-us-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/december/volvo-trucks-introduces-the-volvo-vnr-electric-model-in-the-us-canada/"/>
         <updated>2020-12-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today announced the commercial introduction and sales start of its zero tailpipe emission, battery-electric vehicle to the North American market. The Class 8 Volvo VNR Electric truck model has a scheduled production start of early 2021.]]></content>
         <published>2020-12-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Tri-State Truck Center in Springfield Missouri Celebrates Expansion of Volvo Trucks Dealership]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/tri-state-truck-center-in-springfield-missouri-celebrates-expansion-of-volvo-trucks-dealership/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/tri-state-truck-center-in-springfield-missouri-celebrates-expansion-of-volvo-trucks-dealership/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/tri-state-truck-center-in-springfield-missouri-celebrates-expansion-of-volvo-trucks-dealership/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/tri-state-truck-center-in-springfield-missouri-celebrates-expansion-of-volvo-trucks-dealership/"/>
         <updated>2020-11-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealer Tri-State Truck Center has completed a major rebuild and expansion of its location in Springfield, Missouri.]]></content>
         <published>2020-11-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Makes Latest-Generation D13 Turbo Compound Engine Standard in all VNL 740, 760 and 860 Models]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/volvo-trucks-makes-latest-generation-d13-turbo-compound-engine-standard-in-all-vnl/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/volvo-trucks-makes-latest-generation-d13-turbo-compound-engine-standard-in-all-vnl/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/volvo-trucks-makes-latest-generation-d13-turbo-compound-engine-standard-in-all-vnl/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/volvo-trucks-makes-latest-generation-d13-turbo-compound-engine-standard-in-all-vnl/"/>
         <updated>2020-11-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has taken strategic measures to continue setting new standards in fuel efficiency and providing best-in-class fuel economy for its customers while reducing its products’ greenhouse gas emissions footprint. And because increasing operational efficiency and cutting fuel costs is more important today than ever before, the company has further enhanced its fuel economy packages for both the Volvo VNL and VNR models.]]></content>
         <published>2020-11-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Announces Launch of VNR Electric Model in United States, Canada]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/volvo-trucks-north-america-announces-launch-of-vnr-electric-model-in-united-states/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/november/volvo-trucks-north-america-announces-launch-of-vnr-electric-model-in-united-states/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/volvo-trucks-north-america-announces-launch-of-vnr-electric-model-in-united-states/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/november/volvo-trucks-north-america-announces-launch-of-vnr-electric-model-in-united-states/"/>
         <updated>2020-11-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced it will begin selling the Volvo VNR Electric truck model on Dec. 3, 2020.]]></content>
         <published>2020-11-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo LIGHTS Team Helps Facilitate Authorization for Public MDHD EV Charging Stations in California | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-lights-team-helps-facilitate-authorization-for-public-mdhd-ev-charging-stations-in-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-lights-team-helps-facilitate-authorization-for-public-mdhd-ev-charging-stations-in-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-lights-team-helps-facilitate-authorization-for-public-mdhd-ev-charging-stations-in-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-lights-team-helps-facilitate-authorization-for-public-mdhd-ev-charging-stations-in-california/"/>
         <updated>2020-10-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today announced an important milestone in the path to the wide-scale electrification of medium- and heavy-duty trucks via the expansion of public charging options for fleet operators.]]></content>
         <published>2020-10-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues Exclusive Sponsorship of America’s Road Team in 2021]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-trucks-continues-exclusive-sponsorship-of-america-s-road-team-in-2021/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-trucks-continues-exclusive-sponsorship-of-america-s-road-team-in-2021/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-trucks-continues-exclusive-sponsorship-of-america-s-road-team-in-2021/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-trucks-continues-exclusive-sponsorship-of-america-s-road-team-in-2021/"/>
         <updated>2020-10-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will continue to serve as the exclusive sponsor of the America’s Road Team public outreach program in 2021. Peter Voorhoeve, president of Volvo Trucks North America, made the announcement today at the virtual American Trucking Associations (ATA) Management Conference & Exhibition (MC&E).]]></content>
         <published>2020-10-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Awarded 21 7M to Deploy 70 Class 8 VNR Electric Zero-Emission Trucks]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-trucks-awarded-21-7m-to-deploy-70-class-8-vnr-electric-zero-emission-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/volvo-trucks-awarded-21-7m-to-deploy-70-class-8-vnr-electric-zero-emission-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-trucks-awarded-21-7m-to-deploy-70-class-8-vnr-electric-zero-emission-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/volvo-trucks-awarded-21-7m-to-deploy-70-class-8-vnr-electric-zero-emission-trucks/"/>
         <updated>2020-10-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[This award enables the nation’s largest commercial deployment of Class 8 battery-electric trucks.]]></content>
         <published>2020-10-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Battery-Electric Volvo VNR Truck Leads Port of Long Beach Clean Truck Parade]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/battery-electric-volvo-vnr-truck-leads-port-of-long-beach-clean-truck-parade/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/october/battery-electric-volvo-vnr-truck-leads-port-of-long-beach-clean-truck-parade/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/battery-electric-volvo-vnr-truck-leads-port-of-long-beach-clean-truck-parade/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/october/battery-electric-volvo-vnr-truck-leads-port-of-long-beach-clean-truck-parade/"/>
         <updated>2020-10-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo LIGHTS project partner NFI led Southern California freight movement fleets in a parade of low- and zero-emission trucks to commemorate the opening of the new Port of Long Beach bridge.]]></content>
         <published>2020-10-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo LIGHTS Project Team Wins 2020 Innovation Award from Nonprofit BREATHE Southern California | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/volvo-lights-project-team-wins-2020-innovation-award-from-nonprofit-breathe-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/volvo-lights-project-team-wins-2020-innovation-award-from-nonprofit-breathe-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/volvo-lights-project-team-wins-2020-innovation-award-from-nonprofit-breathe-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/volvo-lights-project-team-wins-2020-innovation-award-from-nonprofit-breathe-southern-california/"/>
         <updated>2020-09-30T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo LIGHTS project in Southern California was named the 2020 Innovation Award Honoree at the recent Breath of Life Awards Gala. The event, which was held virtually Sept. 24, celebrated influential leaders in the Southern California community for accomplishments that align with the organization’s mission of promoting clean air and human health through research, education, advocacy and technology.]]></content>
         <published>2020-09-30T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[NFI Begins Piloting Volvo VNR Electric Heavy-Duty Trucks in Southern California | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/nfi-begins-piloting-volvo-vnr-electric-heavy-duty-trucks-in-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/nfi-begins-piloting-volvo-vnr-electric-heavy-duty-trucks-in-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/nfi-begins-piloting-volvo-vnr-electric-heavy-duty-trucks-in-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/nfi-begins-piloting-volvo-vnr-electric-heavy-duty-trucks-in-southern-california/"/>
         <updated>2020-09-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Through the Volvo LIGHTS project, third-party supply chain solutions provider NFI will demonstrate the ability for battery-electric trucks to successfully transport freight under a variety of operating conditions.]]></content>
         <published>2020-09-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Salutes Professional Truck Drivers Leading United States’ Economic Recovery]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/volvo-trucks-salutes-professional-truck-drivers-leading-united-states-economic-recovery/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/volvo-trucks-salutes-professional-truck-drivers-leading-united-states-economic-recovery/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/volvo-trucks-salutes-professional-truck-drivers-leading-united-states-economic-recovery/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/volvo-trucks-salutes-professional-truck-drivers-leading-united-states-economic-recovery/"/>
         <updated>2020-09-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is celebrating National Truck Driver Appreciation Week, Sept. 13-19, by recognizing the industry’s 3.5 million professional drivers for their role in transporting food, fuel, medications and other essential goods safely and on time, especially this year under the unprecedented conditions created by COVID-19.]]></content>
         <published>2020-09-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Dependable Highway Express Begins Piloting Volvo VNR Electric Heavy-Duty Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/dependable-highway-express-begins-piloting-volvo-vnr-electric-heavy-duty-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/dependable-highway-express-begins-piloting-volvo-vnr-electric-heavy-duty-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/dependable-highway-express-begins-piloting-volvo-vnr-electric-heavy-duty-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/dependable-highway-express-begins-piloting-volvo-vnr-electric-heavy-duty-trucks/"/>
         <updated>2020-09-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Through the Volvo LIGHTS project, leading freight company Dependable Highway Express will demonstrate the ability for battery-electric trucks to successfully transport goods in daily routes.]]></content>
         <published>2020-09-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Integrated Solution for Fleets and Drivers memorandum signed by Samsara | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/integrated-solution-for-fleets-and-drivers-memorandum-signed-by-samsara/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/september/integrated-solution-for-fleets-and-drivers-memorandum-signed-by-samsara/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/integrated-solution-for-fleets-and-drivers-memorandum-signed-by-samsara/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/september/integrated-solution-for-fleets-and-drivers-memorandum-signed-by-samsara/"/>
         <updated>2020-09-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America, a leader in connectivity, has entered into a Memorandum of Understanding (MOU) with Samsara, a leader in industrial Internet of Things (IoT).]]></content>
         <published>2020-09-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Electric Truck Charging Options Broadened in North America Through Volvo LIGHTS Project | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/august/electric-truck-charging-options-broadened-in-north-america-through-volvo-lights-project/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/august/electric-truck-charging-options-broadened-in-north-america-through-volvo-lights-project/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/august/electric-truck-charging-options-broadened-in-north-america-through-volvo-lights-project/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/august/electric-truck-charging-options-broadened-in-north-america-through-volvo-lights-project/"/>
         <updated>2020-08-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo LIGHTS project supplier REMA secures Underwriters Laboratories (UL) Certification of Combined Charging System CCS2 Connector.]]></content>
         <published>2020-08-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Vanguard Truck Centers Opens New Volvo Trucks Dealer Facility in Greater Austin Area]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/august/vanguard-truck-centers-opens-new-volvo-trucks-dealer-facility-in-greater-austin-area/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/august/vanguard-truck-centers-opens-new-volvo-trucks-dealer-facility-in-greater-austin-area/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/august/vanguard-truck-centers-opens-new-volvo-trucks-dealer-facility-in-greater-austin-area/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/august/vanguard-truck-centers-opens-new-volvo-trucks-dealer-facility-in-greater-austin-area/"/>
         <updated>2020-08-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealership Vanguard Truck Centers has expanded its operations with the opening of a new location in Georgetown, Tex., which marks the eighth facility in Texas and the 19th overall for the dealer group across six states.]]></content>
         <published>2020-08-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Virtual Walk-Arounds Enable Customers to Review Truck Models Live and in High Definition | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/july/virtual-walk-arounds-enable-customers-to-review-truck-models-live-and-in-high-definition/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/july/virtual-walk-arounds-enable-customers-to-review-truck-models-live-and-in-high-definition/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/july/virtual-walk-arounds-enable-customers-to-review-truck-models-live-and-in-high-definition/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/july/virtual-walk-arounds-enable-customers-to-review-truck-models-live-and-in-high-definition/"/>
         <updated>2020-07-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[As conditions related to COVID-19 persist, Volvo Trucks North America is offering existing and potential customers the opportunity to participate in live video walk-arounds of pilot trucks, providing a high-definition look at the design and engineering details of truck models.]]></content>
         <published>2020-07-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Enhanced Customer Support with Free Extension of Uptime Services Package | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/july/free-extension-of-uptime-services-package/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/july/free-extension-of-uptime-services-package/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/july/free-extension-of-uptime-services-package/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/july/free-extension-of-uptime-services-package/"/>
         <updated>2020-07-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is providing a new level of support to its customers during COVID-19 by extending the coverage period for its Volvo Trucks Uptime Services and support bundle at no cost through the end of the year, or for a minimum of three months (whichever is longer).]]></content>
         <published>2020-07-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Redesigns VAH Model for Maximum Payload and Modern Look]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-redesigns-vah-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-redesigns-vah-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-redesigns-vah-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-redesigns-vah-model/"/>
         <updated>2020-06-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The roll-out of the new Volvo Auto Hauler (VAH), a specialized solution for the auto transport industry, completes the design overhaul of the entire Volvo Trucks North America product portfolio.]]></content>
         <published>2020-06-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Partners with Galfab and Fontaine Modification to Streamline Installation of Roll-Off Bodies]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-partners-with-galfab-and-fontaine-modification/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-partners-with-galfab-and-fontaine-modification/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-partners-with-galfab-and-fontaine-modification/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-partners-with-galfab-and-fontaine-modification/"/>
         <updated>2020-06-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America has announced a collaboration with Galfab to have roll-off bodies available onsite for installation at the Fontaine facility near Volvo Trucks’ Dublin, Va., factory.]]></content>
         <published>2020-06-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Offers New Geotab Telematics Package for Fleets and Drivers]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-offers-new-geotab-telematics-package-for-fleets-and-drivers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-offers-new-geotab-telematics-package-for-fleets-and-drivers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-offers-new-geotab-telematics-package-for-fleets-and-drivers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-offers-new-geotab-telematics-package-for-fleets-and-drivers/"/>
         <updated>2020-06-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America, the industry leader in connectivity, has partnered with Geotab, a global leader in IoT and connected transportation, to offer an integrated, factory-fit telematics solution and best-in-class technology platform to provide comprehensive fleet management, diagnostics, compliance and driver support.]]></content>
         <published>2020-06-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Patrick Shannon Appointed President of VFS North America Region | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/patrick-shannon-appointed-president-of-vfs-north-america-region/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/patrick-shannon-appointed-president-of-vfs-north-america-region/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/patrick-shannon-appointed-president-of-vfs-north-america-region/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/patrick-shannon-appointed-president-of-vfs-north-america-region/"/>
         <updated>2020-06-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Effective July 1st, Shannon will have overall responsibility for Volvo Financial Services’ business operations and financial results in the U.S., Canada and Mexico.]]></content>
         <published>2020-06-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Deploys First Pilot All-Electric VNR Truck at TEC Equipment in Southern California]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-deploys-first-pilot-all-electric-vnr-truck-at-tec-equipment-in-southern-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/volvo-trucks-deploys-first-pilot-all-electric-vnr-truck-at-tec-equipment-in-southern-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-deploys-first-pilot-all-electric-vnr-truck-at-tec-equipment-in-southern-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/volvo-trucks-deploys-first-pilot-all-electric-vnr-truck-at-tec-equipment-in-southern-california/"/>
         <updated>2020-06-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The all-electric Volvo VNR model, which will be used by the dealership for local parts distribution, is the first pilot truck to deploy as part of the Volvo LIGHTS project.]]></content>
         <published>2020-06-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Northwest Equipment Sales Adds First Location in Washington State | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/northwest-equipment-sales-adds-first-location-in-washington-state/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/june/northwest-equipment-sales-adds-first-location-in-washington-state/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/northwest-equipment-sales-adds-first-location-in-washington-state/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/june/northwest-equipment-sales-adds-first-location-in-washington-state/"/>
         <updated>2020-06-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America dealership Northwest Equipment Sales has expanded its operations through the opening of a new location near the Tri-Cities, a growing metropolitan area comprising the greater Kennewick, Richland and Pasco communities in southeast Washington. The state-of-the-art facility, located at 171 Gateway Road in Burbank, Wash., marks the fourth overall site owned by the dealership.]]></content>
         <published>2020-06-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Certified Uptime Process Helps Dealers Keep Customers Running During COVID 19]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-trucks-certified-uptime-process-helps-dealers-keep-customers-running-during-covid-19/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-trucks-certified-uptime-process-helps-dealers-keep-customers-running-during-covid-19/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-trucks-certified-uptime-process-helps-dealers-keep-customers-running-during-covid-19/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-trucks-certified-uptime-process-helps-dealers-keep-customers-running-during-covid-19/"/>
         <updated>2020-05-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Vision Truck Center in Ontario, Canada, has instituted a policy requiring a 100 percent paperless process.]]></content>
         <published>2020-05-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Helps Provide Meals to Feed Truck Drivers on the Road]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-trucks-helps-provide-meals-to-feed-truck-drivers-on-the-road/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-trucks-helps-provide-meals-to-feed-truck-drivers-on-the-road/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-trucks-helps-provide-meals-to-feed-truck-drivers-on-the-road/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-trucks-helps-provide-meals-to-feed-truck-drivers-on-the-road/"/>
         <updated>2020-05-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks Helps Provide Meals to Feed Truck Drivers on the Road Through Sponsoring CDLLife “Fueling Our Heroes” Initiative]]></content>
         <published>2020-05-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[A Letter from Our President Regarding COVID-19 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/peter-voorhoeve-covid-response-customer-letter/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/peter-voorhoeve-covid-response-customer-letter/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/peter-voorhoeve-covid-response-customer-letter/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/peter-voorhoeve-covid-response-customer-letter/"/>
         <updated>2020-05-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[As our industry and society as a whole face significant challenges over the weeks ahead, Volvo Trucks and our North America Dealer Network want to assure you that we are here to support your business, your drivers and your equipment, diligently every day.]]></content>
         <published>2020-05-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Financial Services Extends Enhanced Finance Programs to Customers in US Canada | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-financial-services-extends-enhanced-finance-programs-to-customers-in-us-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/may/volvo-financial-services-extends-enhanced-finance-programs-to-customers-in-us-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-financial-services-extends-enhanced-finance-programs-to-customers-in-us-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/may/volvo-financial-services-extends-enhanced-finance-programs-to-customers-in-us-canada/"/>
         <updated>2020-05-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Financial Services continues to seek out ways to help our customers through these difficult times.]]></content>
         <published>2020-05-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues to Offer Industry-Leading Uptime Support During COVID-19]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-continues-to-offer-industry-leading-uptime-support-during-covid-19/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-continues-to-offer-industry-leading-uptime-support-during-covid-19/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-continues-to-offer-industry-leading-uptime-support-during-covid-19/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-continues-to-offer-industry-leading-uptime-support-during-covid-19/"/>
         <updated>2020-04-30T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America continues to provide customers with exceptional uptime support amid the current COVID-19 situation.]]></content>
         <published>2020-04-30T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Recognizes Vision Truck Group as 2019 Canada Dealer of the Year]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-recognizes-vision-truck-group-as-2019-canada-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-recognizes-vision-truck-group-as-2019-canada-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-recognizes-vision-truck-group-as-2019-canada-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-recognizes-vision-truck-group-as-2019-canada-dealer-of-the-year/"/>
         <updated>2020-04-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks has named Vision Truck Group, headquartered in Brampton, Ontario, as its 2019 Canada Dealer of the Year.]]></content>
         <published>2020-04-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Offers Free Online Technician Courses for High School]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-offers-free-online-technician-courses-for-high-school/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-offers-free-online-technician-courses-for-high-school/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-offers-free-online-technician-courses-for-high-school/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-offers-free-online-technician-courses-for-high-school/"/>
         <updated>2020-04-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is providing free 90-day eLearning for high school and secondary technical education]]></content>
         <published>2020-04-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Video | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-north-america-video/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-north-america-video/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-north-america-video/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-north-america-video/"/>
         <updated>2020-04-27T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The New York Festivals TV & Film Awards celebrate the world’s best television and films.]]></content>
         <published>2020-04-27T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Offers Donations]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-north-america-offers-donations/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-north-america-offers-donations/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-north-america-offers-donations/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-north-america-offers-donations/"/>
         <updated>2020-04-27T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is helping the communities where its employees live and work by producing Personal Protective Equipment for local medical facilities]]></content>
         <published>2020-04-27T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Provides Customers 24 7 Remote Access]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-provides-customers-24-7-remote-access/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-trucks-provides-customers-24-7-remote-access/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-provides-customers-24-7-remote-access/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-trucks-provides-customers-24-7-remote-access/"/>
         <updated>2020-04-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Under the current COVID-19 working conditions, Volvo Trucks North America is encouraging customers to utilize the Volvo SELECT Part Store, the company’s leading e-commerce parts platform, replacing in-person transactions with the convenience of online ordering and direct delivery.]]></content>
         <published>2020-04-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Financial Services Offers Finance Program to Help Customers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-financial-services-offers-finance-program-to-help-customers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/april/volvo-financial-services-offers-finance-program-to-help-customers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-financial-services-offers-finance-program-to-help-customers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/april/volvo-financial-services-offers-finance-program-to-help-customers/"/>
         <updated>2020-04-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Financial Services (VFS) is offering customers in the U.S. an enhanced finance program on the purchase or lease of a model year 2020 or 2019 Volvo VNL, VNR, VNX or VHD model during this time of financial uncertainty as a result of COVID-19.]]></content>
         <published>2020-04-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Partners with Fontaine Modification | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/volvo-trucks-partners-with-fontaine-modification/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/volvo-trucks-partners-with-fontaine-modification/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/volvo-trucks-partners-with-fontaine-modification/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/volvo-trucks-partners-with-fontaine-modification/"/>
         <updated>2020-03-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Auto Hauler (VAH) 300, Volvo Trucks’ signature day cab in the North American market, is now available for order at an unladen 94.5-inch height. This reduced-height cab option is currently the lowest in the industry by 1.5 inches, offering auto haulers best-in-class versatility for local and regional automobile transport applications.]]></content>
         <published>2020-03-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Unveils Tougher Smarter Volvo VHD| Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/volvo-trucks-unveils-tougher-smarter-volvo-vhd/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/volvo-trucks-unveils-tougher-smarter-volvo-vhd/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/volvo-trucks-unveils-tougher-smarter-volvo-vhd/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/volvo-trucks-unveils-tougher-smarter-volvo-vhd/"/>
         <updated>2020-03-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VHD Vocational Series offers not only a fresh, modern look, but also the latest in safety and uptime solutions for vocational applications.]]></content>
         <published>2020-03-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[CONEXPO Cancellation | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/conexpo-cancellation/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/march/conexpo-cancellation/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/conexpo-cancellation/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/march/conexpo-cancellation/"/>
         <updated>2020-03-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Auto Hauler (VAH) 300, Volvo Trucks’ signature day cab in the North American market, is now available for order at an unladen 94.5-inch height. This reduced-height cab option is currently the lowest in the industry by 1.5 inches, offering auto haulers best-in-class versatility for local and regional automobile transport applications.]]></content>
         <published>2020-03-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit the Latest in Uptime and Connectivity Solutions at TMC]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-to-exhibit-the-latest-in-uptime-and-connectivity-solutions-at-tmc/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-to-exhibit-the-latest-in-uptime-and-connectivity-solutions-at-tmc/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-to-exhibit-the-latest-in-uptime-and-connectivity-solutions-at-tmc/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-to-exhibit-the-latest-in-uptime-and-connectivity-solutions-at-tmc/"/>
         <updated>2020-02-21T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will display the most recent upgrades to its uptime and connectivity solutions in its booth (No. 2203) at the Technology & Maintenance Council (TMC) 2020 Annual Meeting February 24-27, 2020 at the Georgia World Congress Center in Atlanta. Attendees will experience first-hand how Volvo VNL and VNR models increase customers’ productivity and feature the latest in connected solutions.]]></content>
         <published>2020-02-21T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Announces Driver Display Activation for Remote Programming, Further Improving Uptime | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-north-america-announces/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-north-america-announces/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-north-america-announces/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-north-america-announces/"/>
         <updated>2020-02-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks is rolling out a new version of its Remote Programming services called Driver Display Activation. The new service allows drivers to update software and parameters at any time, from anywhere they have cellular service. Remote Programming Driver Display Activation will be available Q4 2020.]]></content>
         <published>2020-02-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names M and K Truck Centers 2019 US Dealer Group of the Year]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-names-m-and-k-truck-centers-2019-us-dealer-group-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/volvo-trucks-names-m-and-k-truck-centers-2019-us-dealer-group-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-names-m-and-k-truck-centers-2019-us-dealer-group-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/volvo-trucks-names-m-and-k-truck-centers-2019-us-dealer-group-of-the-year/"/>
         <updated>2020-02-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks has awarded M&K Truck Centers headquartered in Byron Center, Michigan, and their other 15 Volvo Trucks dealer locations, as its 2019 U.S. Dealer Group of the Year. Volvo Trucks also honored its top regional dealership groups in the United States at the recent American Truck Dealers (ATD) Show in Las Vegas, Nevada.]]></content>
         <published>2020-02-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Demonstrates Pilot All-Electric VNR Models as Part of Volvo LIGHTS Innovation Showcase | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/all-electric-vnr-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/all-electric-vnr-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/all-electric-vnr-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/all-electric-vnr-models/"/>
         <updated>2020-02-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America offered a first look at its Class 8 battery-electric project trucks during an exclusive event at TEC Equipment dealership in Fontana, California]]></content>
         <published>2020-02-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit Power and Productivity at World of Concrete | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/world-of-concrete/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/february/world-of-concrete/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/world-of-concrete/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/february/world-of-concrete/"/>
         <updated>2020-02-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America will demonstrate how the Volvo VHD series makes hard work easy at its booth (No. C6813) at the World of Concrete show February 4-7, 2020 at the Las Vegas Convention Center. An eye-catching pink Volvo VHD 300 with a mixer body and a very special purpose will be the highlight of the booth.]]></content>
         <published>2020-02-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Dealer Hudson County Motors Improves Customer Experience with New Facility]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2020/january/volvo-trucks-dealer-hudson-county-motors-improves-customer-experience-with-new-facility/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2020/january/volvo-trucks-dealer-hudson-county-motors-improves-customer-experience-with-new-facility/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2020/january/volvo-trucks-dealer-hudson-county-motors-improves-customer-experience-with-new-facility/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2020/january/volvo-trucks-dealer-hudson-county-motors-improves-customer-experience-with-new-facility/"/>
         <updated>2020-01-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America’s Hudson County Motors dealership recently expanded its offerings, relocating to a brand-new facility in Secaucus, New Jersey.]]></content>
         <published>2020-01-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Reaches 200000 Unit Connectivity Milestone]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-reaches-200000-unit-connectivity-milestone/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-reaches-200000-unit-connectivity-milestone/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-reaches-200000-unit-connectivity-milestone/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-reaches-200000-unit-connectivity-milestone/"/>
         <updated>2019-10-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[As a global leader in connectivity, Volvo Trucks is at the forefront of developing, testing and introducing commercially viable transport solutions equipped with state-of-the-art technologies. The company announced a milestone of reaching over 200,000 connected vehicles in North America on October 28, 2019 at the North American Commercial Vehicle (NACV) Show in Atlanta, Georgia.]]></content>
         <published>2019-10-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Customers Participate in 2019 Run]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-customers-participate-in-2019-run/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-customers-participate-in-2019-run/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-customers-participate-in-2019-run/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-customers-participate-in-2019-run/"/>
         <updated>2019-10-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[C&S Wholesale Grocers, the largest wholesale grocery distributor in the United States, and Ploger Transportation, a leading regional carrier based in Norwalk, Ohio, participated in the 2019 Run on Less Regional initiative driving Volvo VNRs.]]></content>
         <published>2019-10-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks New VNR 660 Model Offers Lighter Weight Shorter Length Solutions | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-new-vnr-660-model-offers-lighter-weight-shorter-length-solutions/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-new-vnr-660-model-offers-lighter-weight-shorter-length-solutions/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-new-vnr-660-model-offers-lighter-weight-shorter-length-solutions/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-new-vnr-660-model-offers-lighter-weight-shorter-length-solutions/"/>
         <updated>2019-10-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America introduces the new Volvo VNR 660 truck model, expanding its offerings for regional-haul applications with specs related to length, weight and driver comfort.]]></content>
         <published>2019-10-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Adds FlowBelow to Aerodynamic Offerings]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-adds-flowbelow-to-aerodynamic-offerings/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-north-america-adds-flowbelow-to-aerodynamic-offerings/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-adds-flowbelow-to-aerodynamic-offerings/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-north-america-adds-flowbelow-to-aerodynamic-offerings/"/>
         <updated>2019-10-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks introduces the FlowBelow Tractor AeroKit, which includes a system of wheel covers and fairings designed for improved aerodynamics and fuel efficiency, as a factory-installed option in Q2 2020. The announcement was made on October 28, 2019 at the North American Commercial Vehicle (NACV) Show in Atlanta, Georgia.]]></content>
         <published>2019-10-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces Continued Sponsorship of America’s Road Team in 2020 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-in-2020/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-in-2020/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-in-2020/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-in-2020/"/>
         <updated>2019-10-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will continue to serve as the exclusive sponsor of the America’s Road Team public outreach program in 2020.]]></content>
         <published>2019-10-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues to Offer Customers Product Enhancements and Industry-Leading Innovations | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-continues-to-offer-customers-product-enhancements-and-industry-leading-innovations/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-continues-to-offer-customers-product-enhancements-and-industry-leading-innovations/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-continues-to-offer-customers-product-enhancements-and-industry-leading-innovations/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-continues-to-offer-customers-product-enhancements-and-industry-leading-innovations/"/>
         <updated>2019-10-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America introduces the new Volvo VNR 660 truck model, expanding its offerings for regional-haul applications with specs related to length, weight and driver comfort.]]></content>
         <published>2019-10-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Partners with Geotab to Deliver Streamlined FMCSA-Compliant ELD]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-partners-with-geotab-to-deliver-streamlined-fmcsa-compliant-eld/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/volvo-trucks-partners-with-geotab-to-deliver-streamlined-fmcsa-compliant-eld/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-partners-with-geotab-to-deliver-streamlined-fmcsa-compliant-eld/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/volvo-trucks-partners-with-geotab-to-deliver-streamlined-fmcsa-compliant-eld/"/>
         <updated>2019-10-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks has partnered with world-class telematics leader Geotab to provide an integrated Electronic Logging Device (ELD) solution for all Volvo-powered trucks model-year 2015 and newer.]]></content>
         <published>2019-10-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Moving Ahead: Rapidly Evolving Trucking Industry Diversifies, Attracting Top Female Talent | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/moving-ahead---rapidly-evolving-trucking-industry-diversifies-attracting-top-female-talent/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/october/moving-ahead---rapidly-evolving-trucking-industry-diversifies-attracting-top-female-talent/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/moving-ahead---rapidly-evolving-trucking-industry-diversifies-attracting-top-female-talent/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/october/moving-ahead---rapidly-evolving-trucking-industry-diversifies-attracting-top-female-talent/"/>
         <updated>2019-10-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will continue to serve as the exclusive sponsor of the America’s Road Team public outreach program in 2020.]]></content>
         <published>2019-10-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Watch Reactions of Truck Drivers Getting Their Necks Hammered By a MMA Chiropractor | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/watch-reactions-of-truck-drivers-getting-their-necks-hammered-by-a-mma-chiropractor/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/watch-reactions-of-truck-drivers-getting-their-necks-hammered-by-a-mma-chiropractor/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/watch-reactions-of-truck-drivers-getting-their-necks-hammered-by-a-mma-chiropractor/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/watch-reactions-of-truck-drivers-getting-their-necks-hammered-by-a-mma-chiropractor/"/>
         <updated>2019-09-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Financial Services (VFS) is offering customers in the U.S. an enhanced finance program on the purchase or lease of a model year 2020 or 2019 Volvo VNL, VNR, VNX or VHD model during this time of financial uncertainty as a result of COVID-19.]]></content>
         <published>2019-09-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Brings Volvo Dynamic Steering to North America]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/volvo-trucks-brings-volvo-dynamic-steering-to-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/volvo-trucks-brings-volvo-dynamic-steering-to-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/volvo-trucks-brings-volvo-dynamic-steering-to-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/volvo-trucks-brings-volvo-dynamic-steering-to-north-america/"/>
         <updated>2019-09-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Dynamic Steering (VDS), a world-class technical innovation, is an ultra-responsive steering system designed to lessen steering force up to 85%, helping reduce driver fatigue and increase road safety.]]></content>
         <published>2019-09-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Uptime Further Improved with Volvo Trucks New Dynamic Maintenance Service]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/uptime-further-improved-with-volvo-trucks-new-dynamic-maintenance-service/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/september/uptime-further-improved-with-volvo-trucks-new-dynamic-maintenance-service/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/uptime-further-improved-with-volvo-trucks-new-dynamic-maintenance-service/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/september/uptime-further-improved-with-volvo-trucks-new-dynamic-maintenance-service/"/>
         <updated>2019-09-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks introduces dynamic maintenance, a connected vehicle maintenance service which seeks to improve fleet operations efficiency through proactive and flexible vehicle-specific maintenance planning.]]></content>
         <published>2019-09-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks New Communications Campaign Spotlights How Customers Can Live a Little and Save a Lot | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/august/volvo-trucks-new-communications-campaign-spotlights-how-customers-can-live-a-little-and-save-a-lot/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/august/volvo-trucks-new-communications-campaign-spotlights-how-customers-can-live-a-little-and-save-a-lot/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/august/volvo-trucks-new-communications-campaign-spotlights-how-customers-can-live-a-little-and-save-a-lot/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/august/volvo-trucks-new-communications-campaign-spotlights-how-customers-can-live-a-little-and-save-a-lot/"/>
         <updated>2019-08-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Get up to 11% fuel savings with the Volvo VNL paired with the new Volvo D13TC engine.]]></content>
         <published>2019-08-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces Enhanced Turbo Compound Engine in VNL Models | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/august/volvo-trucks-introduces-enhanced-turbo-compound-engine-in-vnl-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/august/volvo-trucks-introduces-enhanced-turbo-compound-engine-in-vnl-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/august/volvo-trucks-introduces-enhanced-turbo-compound-engine-in-vnl-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/august/volvo-trucks-introduces-enhanced-turbo-compound-engine-in-vnl-models/"/>
         <updated>2019-08-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is introducing the next generation of its Turbo Compound technology, providing up to an additional 3% improvement in fuel efficiency over the current 13-liter Turbo Compound engine, the D13TC.]]></content>
         <published>2019-08-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[NRV Plant Investment to Boost Quality for Volvo Trucks Customers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/nrv-plant-investment-to-boost-quality-for-volvo-trucks-customers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/nrv-plant-investment-to-boost-quality-for-volvo-trucks-customers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/nrv-plant-investment-to-boost-quality-for-volvo-trucks-customers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/nrv-plant-investment-to-boost-quality-for-volvo-trucks-customers/"/>
         <updated>2019-06-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Group today announced plans to invest nearly $400 million over six years to upgrade the New River Valley, Virginia plant that produces all Volvo trucks sold in North America.]]></content>
         <published>2019-06-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Introduce Next Iteration of Volvo Active Driver Assist | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-trucks-to-introduce-next-iteration-of-volvo-active-driver-assist/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-trucks-to-introduce-next-iteration-of-volvo-active-driver-assist/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-trucks-to-introduce-next-iteration-of-volvo-active-driver-assist/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-trucks-to-introduce-next-iteration-of-volvo-active-driver-assist/"/>
         <updated>2019-06-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Active Driver Assist (VADA) 2.0, a comprehensive collision mitigation system, will be made standard in the new Volvo VNR and VNL models, and available on VNX models, later this year.]]></content>
         <published>2019-06-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Teams Up With Perceptive Automata and DHE to Explore Human Behavior Prediction | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-teams-up-with-perceptive-automata-and-dhe-to-explore-human-behavior-prediction/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-teams-up-with-perceptive-automata-and-dhe-to-explore-human-behavior-prediction/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-teams-up-with-perceptive-automata-and-dhe-to-explore-human-behavior-prediction/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-teams-up-with-perceptive-automata-and-dhe-to-explore-human-behavior-prediction/"/>
         <updated>2019-06-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks is revolutionizing the used truck industry with the introduction of its Volvo Certified program, headlined by the factory-backed Volvo Certified Warranty for pre-owned trucks.]]></content>
         <published>2019-06-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Launches Nationwide Warranty Program for Pre-Owned Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-trucks-launches-nationwide-warranty-program-for-preowned-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/june/volvo-trucks-launches-nationwide-warranty-program-for-preowned-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-trucks-launches-nationwide-warranty-program-for-preowned-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/june/volvo-trucks-launches-nationwide-warranty-program-for-preowned-trucks/"/>
         <updated>2019-06-04T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks is revolutionizing the used truck industry with the introduction of its Volvo Certified program, headlined by the factory-backed Volvo Certified Warranty for pre-owned trucks.]]></content>
         <published>2019-06-04T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Honors Military Heroes During Memorial Day Weekend with Reflections from the Wall Truck | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/may/volvo-trucks-honors-military-heroes-during-memorial-day-weekend-with-reflections-from-the-wall-truck/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/may/volvo-trucks-honors-military-heroes-during-memorial-day-weekend-with-reflections-from-the-wall-truck/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/may/volvo-trucks-honors-military-heroes-during-memorial-day-weekend-with-reflections-from-the-wall-truck/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/may/volvo-trucks-honors-military-heroes-during-memorial-day-weekend-with-reflections-from-the-wall-truck/"/>
         <updated>2019-05-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will continue to serve as the exclusive sponsor of the America’s Road Team public outreach program in 2020.]]></content>
         <published>2019-05-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[New VTNA Press Release | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/may/luz-elena-jurado-appointed-managing-director-for-volvo-trucks-in-mexico/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/may/luz-elena-jurado-appointed-managing-director-for-volvo-trucks-in-mexico/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/may/luz-elena-jurado-appointed-managing-director-for-volvo-trucks-in-mexico/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/may/luz-elena-jurado-appointed-managing-director-for-volvo-trucks-in-mexico/"/>
         <updated>2019-05-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will continue to serve as the exclusive sponsor of the America’s Road Team public outreach program in 2020.]]></content>
         <published>2019-05-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands Over-the-Air Offerings with New Parameter Updates | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/april/volvo-trucks-expands-over-the-air-offerings-with-new-parameter-updates/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/april/volvo-trucks-expands-over-the-air-offerings-with-new-parameter-updates/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/april/volvo-trucks-expands-over-the-air-offerings-with-new-parameter-updates/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/april/volvo-trucks-expands-over-the-air-offerings-with-new-parameter-updates/"/>
         <updated>2019-04-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is introducing the next generation of its Turbo Compound technology, providing up to an additional 3% improvement in fuel efficiency over the current 13-liter Turbo Compound engine, the D13TC.]]></content>
         <published>2019-04-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Connecting the Bigger Picture | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/april/connecting-the-bigger-picture/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/april/connecting-the-bigger-picture/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/april/connecting-the-bigger-picture/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/april/connecting-the-bigger-picture/"/>
         <updated>2019-04-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is introducing the next generation of its Turbo Compound technology, providing up to an additional 3% improvement in fuel efficiency over the current 13-liter Turbo Compound engine, the D13TC.]]></content>
         <published>2019-04-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Jeff Lester appointed Senior Vice President of US Dealer Sales for Volvo Trucks North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/jeff-lester-appointed-senior-vice-president-of-us-dealer-sales-for-volvo-trucks-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/jeff-lester-appointed-senior-vice-president-of-us-dealer-sales-for-volvo-trucks-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/jeff-lester-appointed-senior-vice-president-of-us-dealer-sales-for-volvo-trucks-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/jeff-lester-appointed-senior-vice-president-of-us-dealer-sales-for-volvo-trucks-north-america/"/>
         <updated>2019-03-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[On March 6, 2019, Volvo Group participated in a demonstration of Eco-Drive technology with a Volvo VNL along two connected freight corridors in Carson, California.]]></content>
         <published>2019-03-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Enhances Uptime and Connectivity Capabilities with New Over-the-Air “Parameter Plus” Subscription Package | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/volvo-trucks-enhances-uptime-and-connectivity-capabilities-with-new-ota-subscription-package/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/volvo-trucks-enhances-uptime-and-connectivity-capabilities-with-new-ota-subscription-package/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/volvo-trucks-enhances-uptime-and-connectivity-capabilities-with-new-ota-subscription-package/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/volvo-trucks-enhances-uptime-and-connectivity-capabilities-with-new-ota-subscription-package/"/>
         <updated>2019-03-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ new Parameter Plus Package allows for up to 50 parameter updates annually per covered vehicle, providing significant value to customers’ bottom lines through maximized uptime.]]></content>
         <published>2019-03-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Group Collaborates with Key California Stakeholders to Showcase Potential of Connected Vehicle Technologies with a Volvo VNL | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/volvo-group-to-showcase-potential-of-connected-vehicle-technologies/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/march/volvo-group-to-showcase-potential-of-connected-vehicle-technologies/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/volvo-group-to-showcase-potential-of-connected-vehicle-technologies/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/march/volvo-group-to-showcase-potential-of-connected-vehicle-technologies/"/>
         <updated>2019-03-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[On March 6, 2019, Volvo Group participated in a demonstration of Eco-Drive technology with a Volvo VNL along two connected freight corridors in Carson, California.]]></content>
         <published>2019-03-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Offer Versatile Workstation for VNL 740 760 and VNX 740 Models | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-to-offer-versatile-workstation-for-vnl-740-760-and-vnx-740-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-to-offer-versatile-workstation-for-vnl-740-760-and-vnx-740-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-to-offer-versatile-workstation-for-vnl-740-760-and-vnx-740-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-to-offer-versatile-workstation-for-vnl-740-760-and-vnx-740-models/"/>
         <updated>2019-02-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks adds an ergonomically advanced workstation to its VNL 760, 740 and VNX 740 models, providing a flexible living environment for thousands of drivers who make their homes on the road.]]></content>
         <published>2019-02-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Hosts 2019-2020 Americas Road Team Captains Ahead of Nationwide Outreach | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-hosts-2019-2020-americas-road-team-captains-ahead-of-nationwide-outreach/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-hosts-2019-2020-americas-road-team-captains-ahead-of-nationwide-outreach/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-hosts-2019-2020-americas-road-team-captains-ahead-of-nationwide-outreach/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-hosts-2019-2020-americas-road-team-captains-ahead-of-nationwide-outreach/"/>
         <updated>2019-02-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks adds an ergonomically advanced workstation to its VNL 760, 740 and VNX 740 models, providing a flexible living environment for thousands of drivers who make their homes on the road.]]></content>
         <published>2019-02-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names General Truck Sales 2018 North American Dealer of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-names-general-truck-sales-2018-north-american-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2019/february/volvo-trucks-names-general-truck-sales-2018-north-american-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-names-general-truck-sales-2018-north-american-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2019/february/volvo-trucks-names-general-truck-sales-2018-north-american-dealer-of-the-year/"/>
         <updated>2019-02-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks adds an ergonomically advanced workstation to its VNL 760, 740 and VNX 740 models, providing a flexible living environment for thousands of drivers who make their homes on the road.]]></content>
         <published>2019-02-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Demonstrate Volvo VNR Electric Models in 2019 and Commercialize in 2020 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/december/volvo-trucks-to-demonstrate-volvo-vnr-electric-models-in-2019-and-commercialize-in-2020/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/december/volvo-trucks-to-demonstrate-volvo-vnr-electric-models-in-2019-and-commercialize-in-2020/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/december/volvo-trucks-to-demonstrate-volvo-vnr-electric-models-in-2019-and-commercialize-in-2020/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/december/volvo-trucks-to-demonstrate-volvo-vnr-electric-models-in-2019-and-commercialize-in-2020/"/>
         <updated>2018-12-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced today that it will introduce all-electric Volvo VNR regional-haul demonstrators in California next year.]]></content>
         <published>2018-12-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Furthers its Focus on Freight Efficiency with New Payload Plus Package | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/december/volvo-trucks-furthers-its-focus-on-freight-efficiency-with-new-payload-plus-package/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/december/volvo-trucks-furthers-its-focus-on-freight-efficiency-with-new-payload-plus-package/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/december/volvo-trucks-furthers-its-focus-on-freight-efficiency-with-new-payload-plus-package/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/december/volvo-trucks-furthers-its-focus-on-freight-efficiency-with-new-payload-plus-package/"/>
         <updated>2018-12-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ new “Payload Plus” packages for the Volvo VNR and VNL series provide significant weight savings.]]></content>
         <published>2018-12-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks and Trimble Transportation Enterprise to Collaborate on Fleet Management Services | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/november/volvo-trucks-and-trimble-transportation-enterprise-to-collaborate-on-fleet-management-services/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/november/volvo-trucks-and-trimble-transportation-enterprise-to-collaborate-on-fleet-management-services/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/november/volvo-trucks-and-trimble-transportation-enterprise-to-collaborate-on-fleet-management-services/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/november/volvo-trucks-and-trimble-transportation-enterprise-to-collaborate-on-fleet-management-services/"/>
         <updated>2018-11-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks in North America announced today it has entered into a memorandum of understanding (MOU) with Trimble Transportation Enterprise (formerly TMW Systems) to develop future transportation management and fleet maintenance products and services.]]></content>
         <published>2018-11-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues Exclusive Sponsorship of America's Road Team in 2019 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-continues-exclusive-sponsorship-of-americas-road-team-in-2019/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-continues-exclusive-sponsorship-of-americas-road-team-in-2019/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-continues-exclusive-sponsorship-of-americas-road-team-in-2019/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-continues-exclusive-sponsorship-of-americas-road-team-in-2019/"/>
         <updated>2018-10-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will again serve as the exclusive sponsor of the America’s Road Team public outreach program in 2019.]]></content>
         <published>2018-10-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ New “Xceed” Efficiency Package Boosts Fuel Efficiency for VNL 760 and VNL 860 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-new-xceed-efficiency-package-boosts-fuel-efficiency-for-vnl-760-and-vnl-860/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-new-xceed-efficiency-package-boosts-fuel-efficiency-for-vnl-760-and-vnl-860/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-new-xceed-efficiency-package-boosts-fuel-efficiency-for-vnl-760-and-vnl-860/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-new-xceed-efficiency-package-boosts-fuel-efficiency-for-vnl-760-and-vnl-860/"/>
         <updated>2018-10-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced today the new Xceed fuel efficiency package for Volvo VNL 760 and VNL 860 models operating in dry van and refrigerated trailer operations. The new fuel efficiency package will be available for order beginning in January of 2019 for 2020 models.]]></content>
         <published>2018-10-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ Collaboration with SAS Enhances Remote Diagnostics through Advanced Analytics and AI | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-collaboration-with-sas-enhances-remote-diagnostics-through-advanced-analytics-and-ai/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-collaboration-with-sas-enhances-remote-diagnostics-through-advanced-analytics-and-ai/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-collaboration-with-sas-enhances-remote-diagnostics-through-advanced-analytics-and-ai/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-collaboration-with-sas-enhances-remote-diagnostics-through-advanced-analytics-and-ai/"/>
         <updated>2018-10-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is further strengthening its portfolio of uptime-boosting services by enhancing Remote Diagnostics with an advanced analytics platform from global analytics leader SAS.]]></content>
         <published>2018-10-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands Remote Programming for Over-the-Air Software and Parameter Updates | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-expands-remote-programming-for-over-the-air-software-and-parameter-updates/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/october/volvo-trucks-expands-remote-programming-for-over-the-air-software-and-parameter-updates/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-expands-remote-programming-for-over-the-air-software-and-parameter-updates/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/october/volvo-trucks-expands-remote-programming-for-over-the-air-software-and-parameter-updates/"/>
         <updated>2018-10-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[All Volvo truck owners in the U.S. and Canada with GHG 2017 Volvo engines equipped with Volvo’s factory-installed connectivity hardware are now eligible for software and parameter updates with Volvo’s Remote Programming. Users can perform updates anywhere in the U.S. and Canada where a cellular connection is available, and at the discretion of the vehicle’s decision maker.]]></content>
         <published>2018-10-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to introduce all-electric trucks in North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-to-introduce-all-electric-trucks-in-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-to-introduce-all-electric-trucks-in-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-to-introduce-all-electric-trucks-in-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-to-introduce-all-electric-trucks-in-north-america/"/>
         <updated>2018-09-27T00:00:00.000Z</updated>
         <content type="html"><![CDATA[As part of an innovative partnership between the Volvo Group, California’s South Coast Air Quality Management District (SCAQMD), Volvo Trucks will introduce all-electric truck demonstrators in California next year, and commercialize them in North America in 2020.]]></content>
         <published>2018-09-27T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ Designers Recognized For Design Excellence with the New Volvo VNL Series | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-designers-recognized-for-design-excellence-with-the-new-volvo-vnl-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-designers-recognized-for-design-excellence-with-the-new-volvo-vnl-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-designers-recognized-for-design-excellence-with-the-new-volvo-vnl-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-designers-recognized-for-design-excellence-with-the-new-volvo-vnl-series/"/>
         <updated>2018-09-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Trucks design team recently received recognition from the Industrial Designers Society of America (IDSA) for their work designing the new Volvo VNL series. Volvo Trucks’ design team received IDSA’s Silver International Design Excellence Awards (IDEA). The annual IDEA competition is the world’s most prestigious and rigorous design competition.]]></content>
         <published>2018-09-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Thanks Professional Truck Drivers the Movers of Our World | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-thanks-professional-truck-drivers-the-movers-of-our-world/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/september/volvo-trucks-thanks-professional-truck-drivers-the-movers-of-our-world/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-thanks-professional-truck-drivers-the-movers-of-our-world/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/september/volvo-trucks-thanks-professional-truck-drivers-the-movers-of-our-world/"/>
         <updated>2018-09-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Leading up to National Truck Driver Appreciation Week, Sept. 9 to 15, Volvo Trucks North America is rolling out a new film to tribute the men and women who literally move our world as professional truck drivers.]]></content>
         <published>2018-09-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Provides Tips for Driving Safely During High Travel Season | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/august/volvo-trucks-provides-tips-for-driving-safely-during-high-travel-season/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/august/volvo-trucks-provides-tips-for-driving-safely-during-high-travel-season/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/august/volvo-trucks-provides-tips-for-driving-safely-during-high-travel-season/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/august/volvo-trucks-provides-tips-for-driving-safely-during-high-travel-season/"/>
         <updated>2018-08-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Each year, millions of drivers hit the road for summer travel, making safety critical, particularly at peak travel times such as the Labor Day weekend.]]></content>
         <published>2018-08-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Welcomes Home the First Volvo Truck Built at New River Valley Facility | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/august/volvo-trucks-welcomes-home-the-first-volvo-truck-built-at-new-river-valley-facility/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/august/volvo-trucks-welcomes-home-the-first-volvo-truck-built-at-new-river-valley-facility/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/august/volvo-trucks-welcomes-home-the-first-volvo-truck-built-at-new-river-valley-facility/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/august/volvo-trucks-welcomes-home-the-first-volvo-truck-built-at-new-river-valley-facility/"/>
         <updated>2018-08-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America recently welcomed home the very first Volvo truck model to roll off the assembly line at its New River Valley assembly facility in Dublin, Virginia.]]></content>
         <published>2018-08-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks VNL 300 Now Available with Cummins ISX12N Near Zero Natural Gas Engine | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/july/volvo-trucks-vnl-300-now-available-with-cummins-isx12n-near-zero-natural-gas-engine/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/july/volvo-trucks-vnl-300-now-available-with-cummins-isx12n-near-zero-natural-gas-engine/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/july/volvo-trucks-vnl-300-now-available-with-cummins-isx12n-near-zero-natural-gas-engine/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/july/volvo-trucks-vnl-300-now-available-with-cummins-isx12n-near-zero-natural-gas-engine/"/>
         <updated>2018-07-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-07-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands Advanced Diesel Technician Training Focus | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/july/volvo-trucks-expands-advanced-diesel-technician-training-focus/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/july/volvo-trucks-expands-advanced-diesel-technician-training-focus/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/july/volvo-trucks-expands-advanced-diesel-technician-training-focus/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/july/volvo-trucks-expands-advanced-diesel-technician-training-focus/"/>
         <updated>2018-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks and FedEx Successfully Demonstrate Truck Platooning on NC 540 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/june/volvo-trucks-and-fedex-successfully-demonstrate-truck-platooning-on-nc-540/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/june/volvo-trucks-and-fedex-successfully-demonstrate-truck-platooning-on-nc-540/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/june/volvo-trucks-and-fedex-successfully-demonstrate-truck-platooning-on-nc-540/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/june/volvo-trucks-and-fedex-successfully-demonstrate-truck-platooning-on-nc-540/"/>
         <updated>2018-06-27T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo owners using the Volvo ASIST service management platform can now access essential case information through the new Volvo ASIST mobile app.]]></content>
         <published>2018-06-27T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Peter Voorhoeve Appointed President of Volvo Trucks North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/june/peter-voorhoeve-appointed-president-of-volvo-trucks-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/june/peter-voorhoeve-appointed-president-of-volvo-trucks-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/june/peter-voorhoeve-appointed-president-of-volvo-trucks-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/june/peter-voorhoeve-appointed-president-of-volvo-trucks-north-america/"/>
         <updated>2018-06-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo owners using the Volvo ASIST service management platform can now access essential case information through the new Volvo ASIST mobile app.]]></content>
         <published>2018-06-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Tribute Trucks Honor Military Heroes During Memorial Day Weekend at US Capital | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-tribute-trucks-honor-military-heroes-during-memorial-day-weekend-at-us-capital/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-tribute-trucks-honor-military-heroes-during-memorial-day-weekend-at-us-capital/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-tribute-trucks-honor-military-heroes-during-memorial-day-weekend-at-us-capital/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-tribute-trucks-honor-military-heroes-during-memorial-day-weekend-at-us-capital/"/>
         <updated>2018-05-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America presented a new Volvo VNL 760 to representatives of the America’s Road Team, the trucking industry’s premier safety outreach program, at the recent Volvo Ocean race stopover in Newport, Rhode Island.]]></content>
         <published>2018-05-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Reinforces Commitment to Professional Truck Drivers with Dedication of New VNL 760 Model to America’s Road Team | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-dedicates-new-vnl-760-model-to-americas-road-team/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-dedicates-new-vnl-760-model-to-americas-road-team/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-dedicates-new-vnl-760-model-to-americas-road-team/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-dedicates-new-vnl-760-model-to-americas-road-team/"/>
         <updated>2018-05-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America presented a new Volvo VNL 760 to representatives of the America’s Road Team, the trucking industry’s premier safety outreach program, at the recent Volvo Ocean race stopover in Newport, Rhode Island.]]></content>
         <published>2018-05-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Salutes Antonio Cruz, McKenzie Tank Lines’ 2017 Driver of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-salutes-antonio-cruz-mckenzie-tank-lines-2017-driver-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-salutes-antonio-cruz-mckenzie-tank-lines-2017-driver-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-salutes-antonio-cruz-mckenzie-tank-lines-2017-driver-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-salutes-antonio-cruz-mckenzie-tank-lines-2017-driver-of-the-year/"/>
         <updated>2018-05-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks recently had the honor of hosting McKenzie Tank Lines at the new Volvo Customer Center for their presentation of the company&rsquo;s inaugural Driver of the Year award.]]></content>
         <published>2018-05-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Configurator | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-rolls-out-online-configurator/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/may/volvo-trucks-rolls-out-online-configurator/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-rolls-out-online-configurator/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/may/volvo-trucks-rolls-out-online-configurator/"/>
         <updated>2018-05-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks recently had the honor of hosting McKenzie Tank Lines at the new Volvo Customer Center for their presentation of the company&rsquo;s inaugural Driver of the Year award.]]></content>
         <published>2018-05-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Celebrates 35 Years of Innovation and Aerodynamic Truck Design in North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-celebrates-35-years-of-innovation-and-aerodynamic-truck-design-in-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-celebrates-35-years-of-innovation-and-aerodynamic-truck-design-in-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-celebrates-35-years-of-innovation-and-aerodynamic-truck-design-in-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-celebrates-35-years-of-innovation-and-aerodynamic-truck-design-in-north-america/"/>
         <updated>2018-04-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[This year marks the 35th anniversary of Volvo’s introduction of the Integral Sleeper, the first North American conventional truck model to offer a modern, streamlined design and a fully integrated sleeper compartment.]]></content>
         <published>2018-04-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names S&amp;S Volvo Truck Sales 2017 North American Dealer of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-names-s-and-s-volvo-truck-sales-2017-north-american-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-names-s-and-s-volvo-truck-sales-2017-north-american-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-names-s-and-s-volvo-truck-sales-2017-north-american-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-names-s-and-s-volvo-truck-sales-2017-north-american-dealer-of-the-year/"/>
         <updated>2018-04-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks has awarded S&S Volvo of Lima, Ohio as its 2017 Dealer of the Year for North America.]]></content>
         <published>2018-04-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Completes Transition to Full Production of New VNL 760 Model for Long-Haul | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-completes-transition-to-full-production-of--new-vnl-760-model-for-long-haul/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/april/volvo-trucks-completes-transition-to-full-production-of--new-vnl-760-model-for-long-haul/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-completes-transition-to-full-production-of--new-vnl-760-model-for-long-haul/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/april/volvo-trucks-completes-transition-to-full-production-of--new-vnl-760-model-for-long-haul/"/>
         <updated>2018-04-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks has completed its transition from production of the legacy VNL 670 model to full production of the new VNL 760.]]></content>
         <published>2018-04-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ New VNX Series is Heavy-Haul’s New Heavy Hitter | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-new-vnx-series-is-heavy-hauls-new-heavy-hitter/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-new-vnx-series-is-heavy-hauls-new-heavy-hitter/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-new-vnx-series-is-heavy-hauls-new-heavy-hitter/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-new-vnx-series-is-heavy-hauls-new-heavy-hitter/"/>
         <updated>2018-03-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks debuted today its rugged, yet refined new VNX series, built specifically for the needs of heavy-haul trucking operations. Available with up to 605 horsepower and 2,050 lb.-ft. of torque, the VNX provides the power and performance demanded for heavy-haul applications such as logging, heavy equipment transport, and long combination vehicles.]]></content>
         <published>2018-03-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Says Remote Programming is Proving to be Next Big Step in Long History of Uptime and Innovation | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-says-remote-programming-proving-next-big-step-in-long-history-of-uptime-innovation/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-says-remote-programming-proving-next-big-step-in-long-history-of-uptime-innovation/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-says-remote-programming-proving-next-big-step-in-long-history-of-uptime-innovation/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-says-remote-programming-proving-next-big-step-in-long-history-of-uptime-innovation/"/>
         <updated>2018-03-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America presented a new Volvo VNL 760 to representatives of the America’s Road Team, the trucking industry’s premier safety outreach program, at the recent Volvo Ocean race stopover in Newport, Rhode Island.]]></content>
         <published>2018-03-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces New Mobile App for ASIST Service Management Platform | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-introduces-new-mobile-app-for-asist-service-management-platform/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/march/volvo-trucks-introduces-new-mobile-app-for-asist-service-management-platform/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-introduces-new-mobile-app-for-asist-service-management-platform/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/march/volvo-trucks-introduces-new-mobile-app-for-asist-service-management-platform/"/>
         <updated>2018-03-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo owners using the Volvo ASIST service management platform can now access essential case information through the new Volvo ASIST mobile app.]]></content>
         <published>2018-03-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks’ Pioneering Automation Work Focuses on Safety and the Ongoing Importance of Professional Drivers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/february/volvo-trucks-pioneering-automation-work-focuses-on-safety-ongoing-importance-of-professional-drivers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/february/volvo-trucks-pioneering-automation-work-focuses-on-safety-ongoing-importance-of-professional-drivers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/february/volvo-trucks-pioneering-automation-work-focuses-on-safety-ongoing-importance-of-professional-drivers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/february/volvo-trucks-pioneering-automation-work-focuses-on-safety-ongoing-importance-of-professional-drivers/"/>
         <updated>2018-02-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-02-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks' North American Dealer Network Surpasses 100 Certified Uptime Centers | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/february/volvo-trucks-north-american-dealer-network-surpasses-100-certified-uptime-centers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/february/volvo-trucks-north-american-dealer-network-surpasses-100-certified-uptime-centers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/february/volvo-trucks-north-american-dealer-network-surpasses-100-certified-uptime-centers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/february/volvo-trucks-north-american-dealer-network-surpasses-100-certified-uptime-centers/"/>
         <updated>2018-02-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-02-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Brings World’s Largest Unboxing and New VNL Series to the “Big Apple” | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-brings-worlds-largest-unboxing-and-new-vnl-series-to-the-big-apple/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-brings-worlds-largest-unboxing-and-new-vnl-series-to-the-big-apple/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-brings-worlds-largest-unboxing-and-new-vnl-series-to-the-big-apple/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-brings-worlds-largest-unboxing-and-new-vnl-series-to-the-big-apple/"/>
         <updated>2018-01-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-01-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces New LED Headlights for VHD Series as Standard Equipment | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-introduces-new-led-headlights-for-vhd-series-as-standard-equipment/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-introduces-new-led-headlights-for-vhd-series-as-standard-equipment/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-introduces-new-led-headlights-for-vhd-series-as-standard-equipment/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-introduces-new-led-headlights-for-vhd-series-as-standard-equipment/"/>
         <updated>2018-01-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-01-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Views Electric Trucks as a Viable Future Freight Transport Solution in North America | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-views-electric-trucks-as-a-viable-future-freight-transport-solution-in-north-america/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-views-electric-trucks-as-a-viable-future-freight-transport-solution-in-north-america/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-views-electric-trucks-as-a-viable-future-freight-transport-solution-in-north-america/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-views-electric-trucks-as-a-viable-future-freight-transport-solution-in-north-america/"/>
         <updated>2018-01-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-01-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Exhibit Vocational Strength and Versatility at World of Concrete 2018 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-to-exhibit-vocational-strength-and-versatility-at-world-of-concrete-2018/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-to-exhibit-vocational-strength-and-versatility-at-world-of-concrete-2018/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-to-exhibit-vocational-strength-and-versatility-at-world-of-concrete-2018/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-to-exhibit-vocational-strength-and-versatility-at-world-of-concrete-2018/"/>
         <updated>2018-01-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-01-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names Wade Long Regional Vice President, Western U.S. Region | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-names-wade-long-regional-vice-president-western-us-region/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2018/january/volvo-trucks-names-wade-long-regional-vice-president-western-us-region/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-names-wade-long-regional-vice-president-western-us-region/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2018/january/volvo-trucks-names-wade-long-regional-vice-president-western-us-region/"/>
         <updated>2018-01-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The new Volvo VNL 300 daycab is now available with the latest version of the Cummins ISX12N “Near Zero” natural gas engine, providing an alternative fuel solution for pick-up and delivery and regional-haul operations.]]></content>
         <published>2018-01-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Expanded Product Range Brings New Market Opportunities for Volvo Trucks in Mexico | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/expanded-product-range-brings-new-market-opportunities-for-volvo-trucks-in-mexico/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/expanded-product-range-brings-new-market-opportunities-for-volvo-trucks-in-mexico/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/expanded-product-range-brings-new-market-opportunities-for-volvo-trucks-in-mexico/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/expanded-product-range-brings-new-market-opportunities-for-volvo-trucks-in-mexico/"/>
         <updated>2017-11-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-11-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces New VNR Series for Regional Haul to the Mexican Market | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-introduces-new-vnr-series-for-regional-haul-to-the-mexican-market/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-introduces-new-vnr-series-for-regional-haul-to-the-mexican-market/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-introduces-new-vnr-series-for-regional-haul-to-the-mexican-market/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-introduces-new-vnr-series-for-regional-haul-to-the-mexican-market/"/>
         <updated>2017-11-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-11-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Sets the Long Haul Standard in Mexico With Debut of the New VNL Series | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-sets-the-long-haul-standard-in-mexico-with-debut-of-the-new-vnl-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-sets-the-long-haul-standard-in-mexico-with-debut-of-the-new-vnl-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-sets-the-long-haul-standard-in-mexico-with-debut-of-the-new-vnl-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-sets-the-long-haul-standard-in-mexico-with-debut-of-the-new-vnl-series/"/>
         <updated>2017-11-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-11-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Outlines Supported Solutions for Complying with ELD Rule | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-outlines-supported-solutions-for-complying-with-eld-rule/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/november/volvo-trucks-outlines-supported-solutions-for-complying-with-eld-rule/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-outlines-supported-solutions-for-complying-with-eld-rule/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/november/volvo-trucks-outlines-supported-solutions-for-complying-with-eld-rule/"/>
         <updated>2017-11-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-11-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Safety Innovations Make New Volvo VNL and VNR Series the Safest Volvo Trucks Ever | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/safety-innovations-make-new-volvo-vnl-and-vnr-series-the-safest-volvo-trucks-ever/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/safety-innovations-make-new-volvo-vnl-and-vnr-series-the-safest-volvo-trucks-ever/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/safety-innovations-make-new-volvo-vnl-and-vnr-series-the-safest-volvo-trucks-ever/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/safety-innovations-make-new-volvo-vnl-and-vnr-series-the-safest-volvo-trucks-ever/"/>
         <updated>2017-10-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-10-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Announces Continued Sponsorship of America's Road Team for 2018 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-for-2018/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-for-2018/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-for-2018/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-announces-continued-sponsorship-of-americas-road-team-for-2018/"/>
         <updated>2017-10-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-10-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Shares its Vision for a World with Zero Traffic Accidents | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-shares-its-vision-for-a-world-with-zero-traffic-accidents/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-shares-its-vision-for-a-world-with-zero-traffic-accidents/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-shares-its-vision-for-a-world-with-zero-traffic-accidents/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-shares-its-vision-for-a-world-with-zero-traffic-accidents/"/>
         <updated>2017-10-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-10-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Dealer Vanguard Truck Centers Adds Houston Texas Location | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-dealer-vanguard-truck-centers-adds-houston-texas-location/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/october/volvo-trucks-dealer-vanguard-truck-centers-adds-houston-texas-location/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-dealer-vanguard-truck-centers-adds-houston-texas-location/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/october/volvo-trucks-dealer-vanguard-truck-centers-adds-houston-texas-location/"/>
         <updated>2017-10-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-10-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Enhances the Volvo VHD Vocational Series with New Interiors for Improved Driver Comfort and Productivity | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/september/volvo-trucks-enhances-the-volvo-vhd-vocational-series-with-new-interiors/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/september/volvo-trucks-enhances-the-volvo-vhd-vocational-series-with-new-interiors/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/september/volvo-trucks-enhances-the-volvo-vhd-vocational-series-with-new-interiors/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/september/volvo-trucks-enhances-the-volvo-vhd-vocational-series-with-new-interiors/"/>
         <updated>2017-09-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[This year marks the 35th anniversary of Volvo’s introduction of the Integral Sleeper, the first North American conventional truck model to offer a modern, streamlined design and a fully integrated sleeper compartment.]]></content>
         <published>2017-09-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Congratulates Ploger Transportation's During Run on Less Roadshow | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/september/volvo-trucks-congratulates-ploger-transportations-during-run-on-less-roadshow/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/september/volvo-trucks-congratulates-ploger-transportations-during-run-on-less-roadshow/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/september/volvo-trucks-congratulates-ploger-transportations-during-run-on-less-roadshow/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/september/volvo-trucks-congratulates-ploger-transportations-during-run-on-less-roadshow/"/>
         <updated>2017-09-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks congratulates Joel Morrow of Ploger Transportation on his exceptional fuel efficiency performance during the Run on Less freight efficiency roadshow. Morrow achieved more than 140 ton miles per gallon – defined as payload moved – over the course of more than 6,300 miles driven, loaded at an average gross weight of nearly 62,000 lbs., during the roadshow, making his operations among the most efficient or the seven participating companies.]]></content>
         <published>2017-09-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America’s ‘World’s Largest Unboxing’ Film Racks Up Nearly 25 Million Views | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-trucks-north-americas-worlds-largest-unboxing-film-racks-up-nearly-25-million-views/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-trucks-north-americas-worlds-largest-unboxing-film-racks-up-nearly-25-million-views/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-trucks-north-americas-worlds-largest-unboxing-film-racks-up-nearly-25-million-views/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-trucks-north-americas-worlds-largest-unboxing-film-racks-up-nearly-25-million-views/"/>
         <updated>2017-07-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America&rsquo;s &ldquo;World&rsquo;s Largest Unboxing&rdquo; film is setting records in more ways than one. Just a little more than two weeks since its launch, the film has been viewed nearly 25 million times, making it Volvo Trucks North America&rsquo;s most-watched film of all time.]]></content>
         <published>2017-07-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo D13 Turbo Compound Engine Powers New Volvo VNL Series | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-d13-turbo-compound-engine-powers-new-volvo-vnl-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-d13-turbo-compound-engine-powers-new-volvo-vnl-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-d13-turbo-compound-engine-powers-new-volvo-vnl-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-d13-turbo-compound-engine-powers-new-volvo-vnl-series/"/>
         <updated>2017-07-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America&rsquo;s &ldquo;World&rsquo;s Largest Unboxing&rdquo; film is setting records in more ways than one. Just a little more than two weeks since its launch, the film has been viewed nearly 25 million times, making it Volvo Trucks North America&rsquo;s most-watched film of all time.]]></content>
         <published>2017-07-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Unveils Highly Anticipated New VNL Series | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-trucks-unveils-highly-anticipated-new-vnl-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-trucks-unveils-highly-anticipated-new-vnl-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-trucks-unveils-highly-anticipated-new-vnl-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-trucks-unveils-highly-anticipated-new-vnl-series/"/>
         <updated>2017-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that it now offers a Genuine Painted Parts Program, delivering genuine, factory-built replacement parts, custom painted for pre-order or quick turnaround.]]></content>
         <published>2017-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Watch 3-year-old Joel Jovine and Volvo Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/watch-3-year-old-joel-jovine-and-volvo-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/watch-3-year-old-joel-jovine-and-volvo-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/watch-3-year-old-joel-jovine-and-volvo-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/watch-3-year-old-joel-jovine-and-volvo-trucks/"/>
         <updated>2017-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that it now offers a Genuine Painted Parts Program, delivering genuine, factory-built replacement parts, custom painted for pre-order or quick turnaround.]]></content>
         <published>2017-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[New Volvo Trucks Customer Center Opens at the New River Valley Plant | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/new-volvo-trucks-customer-center-opens-at-the-new-river-valley-plant/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/new-volvo-trucks-customer-center-opens-at-the-new-river-valley-plant/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/new-volvo-trucks-customer-center-opens-at-the-new-river-valley-plant/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/new-volvo-trucks-customer-center-opens-at-the-new-river-valley-plant/"/>
         <updated>2017-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America&rsquo;s &ldquo;World&rsquo;s Largest Unboxing&rdquo; film is setting records in more ways than one. Just a little more than two weeks since its launch, the film has been viewed nearly 25 million times, making it Volvo Trucks North America&rsquo;s most-watched film of all time.]]></content>
         <published>2017-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Active Driver Assist Now Standard | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-active-driver-assist-now-standard/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/july/volvo-active-driver-assist-now-standard/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-active-driver-assist-now-standard/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/july/volvo-active-driver-assist-now-standard/"/>
         <updated>2017-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America&rsquo;s &ldquo;World&rsquo;s Largest Unboxing&rdquo; film is setting records in more ways than one. Just a little more than two weeks since its launch, the film has been viewed nearly 25 million times, making it Volvo Trucks North America&rsquo;s most-watched film of all time.]]></content>
         <published>2017-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces Genuine Painted Parts Program | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/june/volvo-trucks-introduces-genuine-painted-parts-program/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/june/volvo-trucks-introduces-genuine-painted-parts-program/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/june/volvo-trucks-introduces-genuine-painted-parts-program/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/june/volvo-trucks-introduces-genuine-painted-parts-program/"/>
         <updated>2017-06-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced today that it now offers a Genuine Painted Parts Program, delivering genuine, factory-built replacement parts, custom painted for pre-order or quick turnaround.]]></content>
         <published>2017-06-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[First of New Volvo VNR Regional Haul Models Take to the Road During Media Test Drives | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/june/volvo-trucks-vnr-regional-haul-media-test-drives/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/june/volvo-trucks-vnr-regional-haul-media-test-drives/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/june/volvo-trucks-vnr-regional-haul-media-test-drives/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/june/volvo-trucks-vnr-regional-haul-media-test-drives/"/>
         <updated>2017-06-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[First of New Volvo VNR Regional Haul Models Take to the Road During Media Test Drives]]></content>
         <published>2017-06-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Honors Military Heroes with New Volvo VNR “Ride for Freedom” Truck | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/may/volvo-trucks-honors-military-heroes-with-new-volvo-vnr-ride-for-freedom-truck/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/may/volvo-trucks-honors-military-heroes-with-new-volvo-vnr-ride-for-freedom-truck/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/may/volvo-trucks-honors-military-heroes-with-new-volvo-vnr-ride-for-freedom-truck/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/may/volvo-trucks-honors-military-heroes-with-new-volvo-vnr-ride-for-freedom-truck/"/>
         <updated>2017-05-24T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ New River Valley (NRV) assembly plant in Dublin, Virginia unveiled the design of its 2017 Ride for Freedom truck featuring the all new VNR model.]]></content>
         <published>2017-05-24T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Defines the Shape of Trucks to Come with New VNR Regional Haul Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-defines-the-shape-of-trucks-to-come-with-new-vnr-regional-haul-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-defines-the-shape-of-trucks-to-come-with-new-vnr-regional-haul-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-defines-the-shape-of-trucks-to-come-with-new-vnr-regional-haul-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-defines-the-shape-of-trucks-to-come-with-new-vnr-regional-haul-model/"/>
         <updated>2017-04-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America unveiled today the new Volvo VNR model, a versatile regional haul tractor designed and developed for the modern professional truck driver and the rapidly evolving demands of goods delivery.]]></content>
         <published>2017-04-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Previews New Volvo VNR Regional Haul Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-previews-new-volvo-vnr-regional-haul-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-previews-new-volvo-vnr-regional-haul-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-previews-new-volvo-vnr-regional-haul-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-previews-new-volvo-vnr-regional-haul-model/"/>
         <updated>2017-04-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America offered a glimpse of the shape of trucks to come today with a preview video for its new Volvo VNR regional haul model.]]></content>
         <published>2017-04-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Boosts Uptime Support for Legacy Vehicles through Connectivity Partnership | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-boosts-uptime-support-for-legacy-vehicles-through-connectivity-partnership/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/april/volvo-trucks-boosts-uptime-support-for-legacy-vehicles-through-connectivity-partnership/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-boosts-uptime-support-for-legacy-vehicles-through-connectivity-partnership/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/april/volvo-trucks-boosts-uptime-support-for-legacy-vehicles-through-connectivity-partnership/"/>
         <updated>2017-04-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America unveiled today the new Volvo VNR model, a versatile regional haul tractor designed and developed for the modern professional truck driver and the rapidly evolving demands of goods delivery.]]></content>
         <published>2017-04-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Successfully Demonstrates On-Highway Truck Platooning in California | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/march/volvo-trucks-successfully-demonstrates-on-highway-truck-platooning-in-california/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/march/volvo-trucks-successfully-demonstrates-on-highway-truck-platooning-in-california/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/march/volvo-trucks-successfully-demonstrates-on-highway-truck-platooning-in-california/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/march/volvo-trucks-successfully-demonstrates-on-highway-truck-platooning-in-california/"/>
         <updated>2017-03-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ New River Valley (NRV) assembly plant in Dublin, Virginia unveiled the design of its 2017 Ride for Freedom truck featuring the all new VNR model.]]></content>
         <published>2017-03-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Increases Uptime and Efficiency with Remote Programming | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/march/volvo-trucks-increases-uptime-and-efficiency-with-remote-programming/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/march/volvo-trucks-increases-uptime-and-efficiency-with-remote-programming/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/march/volvo-trucks-increases-uptime-and-efficiency-with-remote-programming/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/march/volvo-trucks-increases-uptime-and-efficiency-with-remote-programming/"/>
         <updated>2017-03-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ New River Valley (NRV) assembly plant in Dublin, Virginia unveiled the design of its 2017 Ride for Freedom truck featuring the all new VNR model.]]></content>
         <published>2017-03-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names General Truck Sales 2016 North American Dealer of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-names-general-truck-sales-2016-north-american-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-names-general-truck-sales-2016-north-american-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-names-general-truck-sales-2016-north-american-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-names-general-truck-sales-2016-north-american-dealer-of-the-year/"/>
         <updated>2017-01-31T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks NJPA Contract VNM, VNL, VNX and VHD models]]></content>
         <published>2017-01-31T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Awarded NJPA Contract for Truck Chassis | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-awarded-njpa-contract-for-truck-chassis/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-awarded-njpa-contract-for-truck-chassis/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-awarded-njpa-contract-for-truck-chassis/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-awarded-njpa-contract-for-truck-chassis/"/>
         <updated>2017-01-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks NJPA Contract VNM, VNL, VNX and VHD models]]></content>
         <published>2017-01-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Delivers First Canadian Models equipped with 2017 Engines to Purolator | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-delivers-first-canadian-models-equipped-with-2017-engines-to-purolator/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2017/january/volvo-trucks-delivers-first-canadian-models-equipped-with-2017-engines-to-purolator/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-delivers-first-canadian-models-equipped-with-2017-engines-to-purolator/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2017/january/volvo-trucks-delivers-first-canadian-models-equipped-with-2017-engines-to-purolator/"/>
         <updated>2017-01-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Canadian Models equipped with 2017 Engines to Purolator]]></content>
         <published>2017-01-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks' 2017 Calendar Now Available for Order | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/december/volvo-trucks-2017-calendar-now-available-for-order/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/december/volvo-trucks-2017-calendar-now-available-for-order/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/december/volvo-trucks-2017-calendar-now-available-for-order/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/december/volvo-trucks-2017-calendar-now-available-for-order/"/>
         <updated>2016-12-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Now available for order, the 2017 Volvo Trucks North America calendar features photos of Volvo’s comprehensive lineup of highway, vocational, auto transport and heavy-haul trucks in dynamic settings.]]></content>
         <published>2016-12-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Awards a Volvo Highway Tractor to Pulaski County Schools | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/december/volvo-trucks-awards-a-volvo-highway-tractor-to-pulaski-county-schools/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/december/volvo-trucks-awards-a-volvo-highway-tractor-to-pulaski-county-schools/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/december/volvo-trucks-awards-a-volvo-highway-tractor-to-pulaski-county-schools/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/december/volvo-trucks-awards-a-volvo-highway-tractor-to-pulaski-county-schools/"/>
         <updated>2016-12-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks’ New River Valley (NRV) Assembly Plant is awarding a 2009 Volvo highway tractor featuring a Volvo D16, a 16-liter 600 horsepower engine, to Pulaski County High Schools for the creation of curriculum where high school students can learn fundamental truck systems, assembly and repair techniques.]]></content>
         <published>2016-12-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Mississippi-Based Volvo Trucks Dealer Expands Operations | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/november/mississippi-based-volvo-trucks-dealer-expands-operations/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/november/mississippi-based-volvo-trucks-dealer-expands-operations/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/november/mississippi-based-volvo-trucks-dealer-expands-operations/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/november/mississippi-based-volvo-trucks-dealer-expands-operations/"/>
         <updated>2016-11-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[One of the largest Volvo Trucks dealerships serving the Gulf Coast region has doubled in size with the recent purchase of three new locations in southern Louisiana. Old River Truck Sales now has six locations and nearly 200 employees in the region.]]></content>
         <published>2016-11-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Academy Receives Gold Brandon Hall Award | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/november/volvo-trucks-academy-receives-gold-brandon-hall-award/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/november/volvo-trucks-academy-receives-gold-brandon-hall-award/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/november/volvo-trucks-academy-receives-gold-brandon-hall-award/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/november/volvo-trucks-academy-receives-gold-brandon-hall-award/"/>
         <updated>2016-11-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The Volvo Certified Uptime Center process is not only positively affecting uptime, it’s also being recognized with a Brandon Hall Group gold award. The Certified Uptime Center training program developed to support dealers won in the Best Learning Program Supporting a Change Transformation Business Strategy..]]></content>
         <published>2016-11-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Continues America’s Road Team Sponsorship in 2017 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-continues-americas-road-team-sponsorship-in-2017/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-continues-americas-road-team-sponsorship-in-2017/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-continues-americas-road-team-sponsorship-in-2017/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-continues-americas-road-team-sponsorship-in-2017/"/>
         <updated>2016-10-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks announced that it will again serve as the exclusive sponsor of the America’s Road Team public outreach program in 2017.]]></content>
         <published>2016-10-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Expands Safety Leadership with Volvo Active Driver Assist | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-active-driver-assist/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-active-driver-assist/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-active-driver-assist/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-active-driver-assist/"/>
         <updated>2016-10-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Today Volvo introduced Active Driver Assist, a comprehensive collision mitigation system that combines both radar and camera capabilities.]]></content>
         <published>2016-10-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks to Develop High-Efficiency Vehicle as Part of SuperTruck II Program | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-to-develop-vehicle-as-part-of-supertruck-ii-program/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-to-develop-vehicle-as-part-of-supertruck-ii-program/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-to-develop-vehicle-as-part-of-supertruck-ii-program/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-to-develop-vehicle-as-part-of-supertruck-ii-program/"/>
         <updated>2016-10-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Working with $20 million in federal funding from the DOE SuperTruck II program, Volvo Trucks will develop an advanced heavy-duty tractor-trailer concept]]></content>
         <published>2016-10-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Enters Agreement with Geotab for Connected Vehicle Services | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-enters-agreement-with-geotab-for-connected-vehicle-services/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/october/volvo-trucks-enters-agreement-with-geotab-for-connected-vehicle-services/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-enters-agreement-with-geotab-for-connected-vehicle-services/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/october/volvo-trucks-enters-agreement-with-geotab-for-connected-vehicle-services/"/>
         <updated>2016-10-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America announced that it has entered into a Memorandum of Understanding (MOU) with Geotab, a global provider of telematics technology.]]></content>
         <published>2016-10-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo’s High-Tech SuperTruck Exceeds Program’s Freight Efficiency Goals | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/september/high-tech-supertruck-exceeds-goals/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/september/high-tech-supertruck-exceeds-goals/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/september/high-tech-supertruck-exceeds-goals/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/september/high-tech-supertruck-exceeds-goals/"/>
         <updated>2016-09-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America today unveiled an innovative SuperTruck demonstrator. Learn more]]></content>
         <published>2016-09-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Introduces New Factory Fill Engine Oil Geared at Reducing Customer Costs | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-introduces-new-factory-fill-engine-oil-geared-at-reducing-customer-costs/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-introduces-new-factory-fill-engine-oil-geared-at-reducing-customer-costs/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-introduces-new-factory-fill-engine-oil-geared-at-reducing-customer-costs/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-introduces-new-factory-fill-engine-oil-geared-at-reducing-customer-costs/"/>
         <updated>2016-08-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[In August of 2016 Volvo will now offer a new factory fill engine oil for Volvo D11, D13 and D16 engines. Read more now]]></content>
         <published>2016-08-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Renews Contract with Decisiv | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-renews-contract-with-decisiv/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-renews-contract-with-decisiv/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-renews-contract-with-decisiv/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-renews-contract-with-decisiv/"/>
         <updated>2016-08-03T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Demonstrating Volvo's commitment to maximize customer uptime, Volvo trucks has renewed it's contract with DECISIV. Find out more now.]]></content>
         <published>2016-08-03T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Releases Latest Video in Welcome to My Cab Series | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-releases-latest-video-in-welcome-to-my-cab-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/august/volvo-trucks-releases-latest-video-in-welcome-to-my-cab-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-releases-latest-video-in-welcome-to-my-cab-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/august/volvo-trucks-releases-latest-video-in-welcome-to-my-cab-series/"/>
         <updated>2016-08-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo introduces it's Turbo Turtle logistics in it's Welcome To My Cab Series featuring Rob Brackett. Watch now]]></content>
         <published>2016-08-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Names Paul Kudla Regional Vice President for Canada | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-names-paul-kudla-regional-vice-president-for-canada/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-names-paul-kudla-regional-vice-president-for-canada/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-names-paul-kudla-regional-vice-president-for-canada/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-names-paul-kudla-regional-vice-president-for-canada/"/>
         <updated>2016-07-28T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks USA appointed Paul Kudla as regional vice president for its Canada region. Read more now]]></content>
         <published>2016-07-28T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Names Jeff Lester Senior Vice President of Sales | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-north-america-names-jeff-lester-senior-vice-president-of-sales/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-north-america-names-jeff-lester-senior-vice-president-of-sales/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-north-america-names-jeff-lester-senior-vice-president-of-sales/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-north-america-names-jeff-lester-senior-vice-president-of-sales/"/>
         <updated>2016-07-20T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America appointed Jeff Lester senior vice president of sales, effective Aug. 1, 2016.]]></content>
         <published>2016-07-20T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Eases Online Parts Purchasing Process with New Cross-Reference Feature of SELECT Part Store | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-eases-online-parts-purchasing-process/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/july/volvo-trucks-eases-online-parts-purchasing-process/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-eases-online-parts-purchasing-process/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/july/volvo-trucks-eases-online-parts-purchasing-process/"/>
         <updated>2016-07-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America recently launched a new parts cross-reference feature for its online SELECT Part Store.]]></content>
         <published>2016-07-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Launches Omnitracs for Volvo Trucks | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-launches-omnitracs-for-volvo-trucks/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-launches-omnitracs-for-volvo-trucks/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-launches-omnitracs-for-volvo-trucks/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-launches-omnitracs-for-volvo-trucks/"/>
         <updated>2016-06-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Today Volvo Trucks launched Omnitracs for Volvo Trucks, a new option for fleet management built on Volvo’s fully integrated Remote Diagnostics hardware]]></content>
         <published>2016-06-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Refuse-Focused Capability at WasteExpo | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-highlights-refuse-capability-in-wasteexpo-lineup/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-highlights-refuse-capability-in-wasteexpo-lineup/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-highlights-refuse-capability-in-wasteexpo-lineup/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-highlights-refuse-capability-in-wasteexpo-lineup/"/>
         <updated>2016-06-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America is bringing its wide range of refuse-focused truck models to WasteExpo 2016. Read more]]></content>
         <published>2016-06-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Honors Military Heroes with Ride for Freedom Truck | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-honors-military-heroes-with-ride-for-freedom-truck-2016/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/june/volvo-trucks-honors-military-heroes-with-ride-for-freedom-truck-2016/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-honors-military-heroes-with-ride-for-freedom-truck-2016/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/june/volvo-trucks-honors-military-heroes-with-ride-for-freedom-truck-2016/"/>
         <updated>2016-06-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Employees at Volvo Trucks’ New River Valley (NRV) assembly plant in Dublin, Virginia recently unveiled their 2016 Ride for Freedom truck]]></content>
         <published>2016-06-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[One Box Exhaust Aftertreatment System | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/may/volvo-trucks-to-offer-a-one-box-exhaust-aftertreatment-system/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/may/volvo-trucks-to-offer-a-one-box-exhaust-aftertreatment-system/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/may/volvo-trucks-to-offer-a-one-box-exhaust-aftertreatment-system/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/may/volvo-trucks-to-offer-a-one-box-exhaust-aftertreatment-system/"/>
         <updated>2016-05-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks North America recently launched a new one-box design for its Exhaust After treatment System (EATS). Learn more]]></content>
         <published>2016-05-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Supertruck Increased Efficiency | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/knowledge-gained-from-supertruck-to-increase-efficiency-performance-in-2017-powertrain-lineup/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/knowledge-gained-from-supertruck-to-increase-efficiency-performance-in-2017-powertrain-lineup/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/knowledge-gained-from-supertruck-to-increase-efficiency-performance-in-2017-powertrain-lineup/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/knowledge-gained-from-supertruck-to-increase-efficiency-performance-in-2017-powertrain-lineup/"/>
         <updated>2016-04-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Supertruck Increased Efficiency | Volvo Trucks USA]]></content>
         <published>2016-04-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks New 2017 Powertrain at Truck World | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-debuts-new-2017-powertrain-at-truck-world/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-debuts-new-2017-powertrain-at-truck-world/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-debuts-new-2017-powertrain-at-truck-world/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-debuts-new-2017-powertrain-at-truck-world/"/>
         <updated>2016-04-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks New 2017 Powertrain at Truck World | Volvo Trucks USA]]></content>
         <published>2016-04-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2017 Volvo Powertrain | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-highlights-new-2017-powertrain-in-truck-world-2016-lineup/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-highlights-new-2017-powertrain-in-truck-world-2016-lineup/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-highlights-new-2017-powertrain-in-truck-world-2016-lineup/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-highlights-new-2017-powertrain-in-truck-world-2016-lineup/"/>
         <updated>2016-04-12T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2017 Volvo Powertrain | Volvo Trucks USA]]></content>
         <published>2016-04-12T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks I See Memorizes Roads | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-i-see-memorizes-roads-to-increase-fuel-efficiency/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-i-see-memorizes-roads-to-increase-fuel-efficiency/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-i-see-memorizes-roads-to-increase-fuel-efficiency/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-i-see-memorizes-roads-to-increase-fuel-efficiency/"/>
         <updated>2016-04-07T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks I See Memorizes Roads | Volvo Trucks USA]]></content>
         <published>2016-04-07T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks 100000th Truck Equipped With I Shift | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-delivers-100000th-truck-equipped-with-i-shift/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-delivers-100000th-truck-equipped-with-i-shift/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-delivers-100000th-truck-equipped-with-i-shift/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-delivers-100000th-truck-equipped-with-i-shift/"/>
         <updated>2016-04-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks 100000th Truck Equipped With I Shift | Volvo Trucks USA]]></content>
         <published>2016-04-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks UAW Agree on Five Year Contract | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-north-america-and-uaw-agree-on-five-year-contract/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/april/volvo-trucks-north-america-and-uaw-agree-on-five-year-contract/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-north-america-and-uaw-agree-on-five-year-contract/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/april/volvo-trucks-north-america-and-uaw-agree-on-five-year-contract/"/>
         <updated>2016-04-06T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks UAW Agree on Five Year Contract | Volvo Trucks USA]]></content>
         <published>2016-04-06T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[I-Shift for Slow Speed Maneuverability | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/new-volvo-i-shift-with-crawler-gears-offers-slow-speed-maneuverability-extreme-startability/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/new-volvo-i-shift-with-crawler-gears-offers-slow-speed-maneuverability-extreme-startability/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/new-volvo-i-shift-with-crawler-gears-offers-slow-speed-maneuverability-extreme-startability/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/new-volvo-i-shift-with-crawler-gears-offers-slow-speed-maneuverability-extreme-startability/"/>
         <updated>2016-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[I-Shift for Slow Speed Maneuverability | Volvo Trucks USA]]></content>
         <published>2016-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Improved Volvo Truck Powertrain | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-powertrain-featuring-increased-power-and-fuel-efficiency/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-powertrain-featuring-increased-power-and-fuel-efficiency/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-powertrain-featuring-increased-power-and-fuel-efficiency/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-powertrain-featuring-increased-power-and-fuel-efficiency/"/>
         <updated>2016-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Improved Volvo Truck Powertrain | Volvo Trucks USA]]></content>
         <published>2016-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[The New Volvo Trucks Logo | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-logo/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-logo/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-logo/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-new-logo/"/>
         <updated>2016-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[The New Volvo Trucks Logo | Volvo Trucks USA]]></content>
         <published>2016-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2017 Volvo Truck Powertrain Production | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-prepares-for-production-of-2017-powertrain-at-hagerstown-maryland-site/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-prepares-for-production-of-2017-powertrain-at-hagerstown-maryland-site/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-prepares-for-production-of-2017-powertrain-at-hagerstown-maryland-site/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-prepares-for-production-of-2017-powertrain-at-hagerstown-maryland-site/"/>
         <updated>2016-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2017 Volvo Truck Powertrain Production | Volvo Trucks USA]]></content>
         <published>2016-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Innovative Engines Improve Efficiency | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-innovative-new-engines-for-increased-fuel-efficiency/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/march/volvo-trucks-unveils-innovative-new-engines-for-increased-fuel-efficiency/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-innovative-new-engines-for-increased-fuel-efficiency/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/march/volvo-trucks-unveils-innovative-new-engines-for-increased-fuel-efficiency/"/>
         <updated>2016-03-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Innovative Engines Improve Efficiency | Volvo Trucks USA]]></content>
         <published>2016-03-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Certified Uptime Center | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-names-first-volvo-certified-uptime-centers/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-names-first-volvo-certified-uptime-centers/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-names-first-volvo-certified-uptime-centers/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-names-first-volvo-certified-uptime-centers/"/>
         <updated>2016-02-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Certified Uptime Center | Volvo Trucks USA]]></content>
         <published>2016-02-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Improving Truck Driver Comfort | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-boosts-driver-comfort-productivity/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-boosts-driver-comfort-productivity/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-boosts-driver-comfort-productivity/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-boosts-driver-comfort-productivity/"/>
         <updated>2016-02-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Improving Truck Driver Comfort | Volvo Trucks USA]]></content>
         <published>2016-02-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo 2015 Northeast Dealer of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-names-transedge-truck-centers-2015-northeast-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-names-transedge-truck-centers-2015-northeast-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-names-transedge-truck-centers-2015-northeast-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-names-transedge-truck-centers-2015-northeast-dealer-of-the-year/"/>
         <updated>2016-02-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo 2015 Northeast Dealer of the Year | Volvo Trucks USA]]></content>
         <published>2016-02-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[North American Trucking Record 2015 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-achieves-record-north-american-results-in-2015/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/february/volvo-trucks-achieves-record-north-american-results-in-2015/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-achieves-record-north-american-results-in-2015/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/february/volvo-trucks-achieves-record-north-american-results-in-2015/"/>
         <updated>2016-02-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[North American Trucking Record 2015 | Volvo Trucks USA]]></content>
         <published>2016-02-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo VHD at The World of Concrete | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/january/volvo-vhd-models-spotlighted-at-world-of-concrete-2016/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/january/volvo-vhd-models-spotlighted-at-world-of-concrete-2016/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/january/volvo-vhd-models-spotlighted-at-world-of-concrete-2016/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/january/volvo-vhd-models-spotlighted-at-world-of-concrete-2016/"/>
         <updated>2016-01-29T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo VHD at The World of Concrete | Volvo Trucks USA]]></content>
         <published>2016-01-29T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[My Cab Video - Americas Road Team | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2016/january/volvo-trucks-highlights-americas-road-team-in-latest-welcome-to-my-cab-video/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2016/january/volvo-trucks-highlights-americas-road-team-in-latest-welcome-to-my-cab-video/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2016/january/volvo-trucks-highlights-americas-road-team-in-latest-welcome-to-my-cab-video/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2016/january/volvo-trucks-highlights-americas-road-team-in-latest-welcome-to-my-cab-video/"/>
         <updated>2016-01-14T00:00:00.000Z</updated>
         <content type="html"><![CDATA[My Cab Video - Americas Road Team | Volvo Trucks USA]]></content>
         <published>2016-01-14T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Greensboro Volvo Truck Sales | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/advantage-truck-center-opens-in-greensboro-expanding-volvo-trucks-sales-and-service/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/advantage-truck-center-opens-in-greensboro-expanding-volvo-trucks-sales-and-service/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/advantage-truck-center-opens-in-greensboro-expanding-volvo-trucks-sales-and-service/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/advantage-truck-center-opens-in-greensboro-expanding-volvo-trucks-sales-and-service/"/>
         <updated>2015-12-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Greensboro Volvo Truck Sales | Volvo Trucks USA]]></content>
         <published>2015-12-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Renewable Diesel for Volvo Truck Engines | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/volvo-trucks-approves-use-of-renewable-diesel-fuel-for-proprietary-engines/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/volvo-trucks-approves-use-of-renewable-diesel-fuel-for-proprietary-engines/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/volvo-trucks-approves-use-of-renewable-diesel-fuel-for-proprietary-engines/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/volvo-trucks-approves-use-of-renewable-diesel-fuel-for-proprietary-engines/"/>
         <updated>2015-12-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Renewable Diesel for Volvo Truck Engines | Volvo Trucks USA]]></content>
         <published>2015-12-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2015 Volvo Trucks Dealer of the Year | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/volvo-trucks-names-mk-truck-centers-2015-north-american-dealer-of-the-year/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/december/volvo-trucks-names-mk-truck-centers-2015-north-american-dealer-of-the-year/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/volvo-trucks-names-mk-truck-centers-2015-north-american-dealer-of-the-year/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/december/volvo-trucks-names-mk-truck-centers-2015-north-american-dealer-of-the-year/"/>
         <updated>2015-12-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2015 Volvo Trucks Dealer of the Year | Volvo Trucks USA]]></content>
         <published>2015-12-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Natural Gas Powered VNM 200 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/manhattan-beer-chooses-natural-gas-powered-volvo-vnm-200-model-tractors/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/manhattan-beer-chooses-natural-gas-powered-volvo-vnm-200-model-tractors/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/manhattan-beer-chooses-natural-gas-powered-volvo-vnm-200-model-tractors/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/manhattan-beer-chooses-natural-gas-powered-volvo-vnm-200-model-tractors/"/>
         <updated>2015-10-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Natural Gas Powered VNM 200 | Volvo Trucks USA]]></content>
         <published>2015-10-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2015 Volvo Truck Safety Award Winners | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/ruan-transportation-searcy-trucking-named-2015-volvo-trucks-safety-award-winners/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/ruan-transportation-searcy-trucking-named-2015-volvo-trucks-safety-award-winners/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/ruan-transportation-searcy-trucking-named-2015-volvo-trucks-safety-award-winners/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/ruan-transportation-searcy-trucking-named-2015-volvo-trucks-safety-award-winners/"/>
         <updated>2015-10-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2015 Volvo Truck Safety Award Winners | Volvo Trucks USA]]></content>
         <published>2015-10-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Americas Road Team 2016 | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/volvo-trucks-renews-sponsorship-of-americas-road-team-for-2016/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/volvo-trucks-renews-sponsorship-of-americas-road-team-for-2016/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/volvo-trucks-renews-sponsorship-of-americas-road-team-for-2016/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/volvo-trucks-renews-sponsorship-of-americas-road-team-for-2016/"/>
         <updated>2015-10-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Americas Road Team 2016 | Volvo Trucks USA]]></content>
         <published>2015-10-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Improving Trucker Uptime | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/volvo-trucks-launches-certified-uptime-centers-to-boost-customer-uptime/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/october/volvo-trucks-launches-certified-uptime-centers-to-boost-customer-uptime/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/volvo-trucks-launches-certified-uptime-centers-to-boost-customer-uptime/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/october/volvo-trucks-launches-certified-uptime-centers-to-boost-customer-uptime/"/>
         <updated>2015-10-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Improving Trucker Uptime | Volvo Trucks USA]]></content>
         <published>2015-10-15T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Ground Breaks at New River Valley | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-trucks-breaks-ground-on-new-customer-experience-center-at-new-river-valley-plant/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-trucks-breaks-ground-on-new-customer-experience-center-at-new-river-valley-plant/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-trucks-breaks-ground-on-new-customer-experience-center-at-new-river-valley-plant/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-trucks-breaks-ground-on-new-customer-experience-center-at-new-river-valley-plant/"/>
         <updated>2015-09-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Ground Breaks at New River Valley | Volvo Trucks USA]]></content>
         <published>2015-09-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Global Aftermarket Competition | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/north-american-teams-to-compete-in-volvos-global-aftermarket-competition/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/north-american-teams-to-compete-in-volvos-global-aftermarket-competition/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/north-american-teams-to-compete-in-volvos-global-aftermarket-competition/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/north-american-teams-to-compete-in-volvos-global-aftermarket-competition/"/>
         <updated>2015-09-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Global Aftermarket Competition | Volvo Trucks USA]]></content>
         <published>2015-09-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Welcome to My Cab Series Video | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-trucks-unveils-latest-video-in-welcome-to-my-cab-series/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-trucks-unveils-latest-video-in-welcome-to-my-cab-series/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-trucks-unveils-latest-video-in-welcome-to-my-cab-series/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-trucks-unveils-latest-video-in-welcome-to-my-cab-series/"/>
         <updated>2015-09-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Welcome to My Cab Series Video | Volvo Trucks USA]]></content>
         <published>2015-09-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Expanded Diagnostic Capabilities | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-improves-uptime-services-with-expanded-diagnostic-capabilities/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/september/volvo-improves-uptime-services-with-expanded-diagnostic-capabilities/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-improves-uptime-services-with-expanded-diagnostic-capabilities/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/september/volvo-improves-uptime-services-with-expanded-diagnostic-capabilities/"/>
         <updated>2015-09-01T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Expanded Diagnostic Capabilities | Volvo Trucks USA]]></content>
         <published>2015-09-01T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Omnitracs and Volvo Partnership | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/volvo-and-omnitracs-to-pursue-partnered-fleet-management-services/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/volvo-and-omnitracs-to-pursue-partnered-fleet-management-services/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/volvo-and-omnitracs-to-pursue-partnered-fleet-management-services/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/volvo-and-omnitracs-to-pursue-partnered-fleet-management-services/"/>
         <updated>2015-08-17T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Omnitracs and Volvo Partnership | Volvo Trucks USA]]></content>
         <published>2015-08-17T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Pre Paid Maintenance Program | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/volvos-pre-paid-maintenance-plans-help-customers-manage-costs/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/volvos-pre-paid-maintenance-plans-help-customers-manage-costs/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/volvos-pre-paid-maintenance-plans-help-customers-manage-costs/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/volvos-pre-paid-maintenance-plans-help-customers-manage-costs/"/>
         <updated>2015-08-10T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Pre Paid Maintenance Program | Volvo Trucks USA]]></content>
         <published>2015-08-10T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[25th Anniversary Silver VNL Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/knight-transportation-marks-25th-anniversary-with-special-silver-volvo-vnl-models/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/august/knight-transportation-marks-25th-anniversary-with-special-silver-volvo-vnl-models/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/knight-transportation-marks-25th-anniversary-with-special-silver-volvo-vnl-models/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/august/knight-transportation-marks-25th-anniversary-with-special-silver-volvo-vnl-models/"/>
         <updated>2015-08-05T00:00:00.000Z</updated>
         <content type="html"><![CDATA[25th Anniversary Silver VNL Model | Volvo Trucks USA]]></content>
         <published>2015-08-05T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo VHD Model Evaluates US Roads | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/july/volvo-vhd-model-to-help-evaluate-us-roads/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/july/volvo-vhd-model-to-help-evaluate-us-roads/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/july/volvo-vhd-model-to-help-evaluate-us-roads/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/july/volvo-vhd-model-to-help-evaluate-us-roads/"/>
         <updated>2015-07-13T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo VHD Model Evaluates US Roads | Volvo Trucks USA]]></content>
         <published>2015-07-13T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks Safety Deadline Moved | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/june/volvo-extends-deadline-for-volvo-trucks-safety-award/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/june/volvo-extends-deadline-for-volvo-trucks-safety-award/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/june/volvo-extends-deadline-for-volvo-trucks-safety-award/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/june/volvo-extends-deadline-for-volvo-trucks-safety-award/"/>
         <updated>2015-06-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Trucks Safety Deadline Moved | Volvo Trucks USA]]></content>
         <published>2015-06-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Honors Military Heroes | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/may/volvo-trucks-ride-for-freedom-truck-honors-americas-military-heroes/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/may/volvo-trucks-ride-for-freedom-truck-honors-americas-military-heroes/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/may/volvo-trucks-ride-for-freedom-truck-honors-americas-military-heroes/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/may/volvo-trucks-ride-for-freedom-truck-honors-americas-military-heroes/"/>
         <updated>2015-05-22T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo Honors Military Heroes | Volvo Trucks USA]]></content>
         <published>2015-05-22T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Biennial Volvo Aftermarket Events | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/may/volvo-dealers-aftermarket-team-focus-on-uptime-at-biennial-event/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/may/volvo-dealers-aftermarket-team-focus-on-uptime-at-biennial-event/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/may/volvo-dealers-aftermarket-team-focus-on-uptime-at-biennial-event/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/may/volvo-dealers-aftermarket-team-focus-on-uptime-at-biennial-event/"/>
         <updated>2015-05-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Biennial Volvo Aftermarket Events | Volvo Trucks USA]]></content>
         <published>2015-05-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Volvo VNX Tridem Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/april/volvo-trucks-furthers-application-specific-offerings-with-volvo-vnx-tridem-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/april/volvo-trucks-furthers-application-specific-offerings-with-volvo-vnx-tridem-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/april/volvo-trucks-furthers-application-specific-offerings-with-volvo-vnx-tridem-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/april/volvo-trucks-furthers-application-specific-offerings-with-volvo-vnx-tridem-model/"/>
         <updated>2015-04-08T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Volvo VNX Tridem Model | Volvo Trucks USA]]></content>
         <published>2015-04-08T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[I-Shift Transmission Monitoring | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-strengthens-uptime-services-with-monitoring-of-i-shift-transmission/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-strengthens-uptime-services-with-monitoring-of-i-shift-transmission/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-strengthens-uptime-services-with-monitoring-of-i-shift-transmission/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-strengthens-uptime-services-with-monitoring-of-i-shift-transmission/"/>
         <updated>2015-03-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[I-Shift Transmission Monitoring | Volvo Trucks USA]]></content>
         <published>2015-03-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Fuel Efficient Powertrain Packages | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-expands-lineup-of-fuel-efficient-powertrain-packages/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-expands-lineup-of-fuel-efficient-powertrain-packages/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-expands-lineup-of-fuel-efficient-powertrain-packages/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-expands-lineup-of-fuel-efficient-powertrain-packages/"/>
         <updated>2015-03-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Fuel Efficient Powertrain Packages | Volvo Trucks USA]]></content>
         <published>2015-03-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Innovative Volvo Trucks Suspension | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/new-volvo-trucks-6x2-suspension-offers-4x2-flexibility/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/new-volvo-trucks-6x2-suspension-offers-4x2-flexibility/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/new-volvo-trucks-6x2-suspension-offers-4x2-flexibility/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/new-volvo-trucks-6x2-suspension-offers-4x2-flexibility/"/>
         <updated>2015-03-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Innovative Volvo Trucks Suspension | Volvo Trucks USA]]></content>
         <published>2015-03-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2015 Mid America Trucking Show | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-at-2015-mid-america-trucking-show/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-at-2015-mid-america-trucking-show/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-at-2015-mid-america-trucking-show/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-at-2015-mid-america-trucking-show/"/>
         <updated>2015-03-23T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2015 Mid America Trucking Show | Volvo Trucks USA]]></content>
         <published>2015-03-23T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[I-Shift Transmission for Severe Duty | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-introduces-i-shift-transmission-for-severe-duty-applications/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/march/volvo-trucks-introduces-i-shift-transmission-for-severe-duty-applications/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-introduces-i-shift-transmission-for-severe-duty-applications/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/march/volvo-trucks-introduces-i-shift-transmission-for-severe-duty-applications/"/>
         <updated>2015-03-18T00:00:00.000Z</updated>
         <content type="html"><![CDATA[I-Shift Transmission for Severe Duty | Volvo Trucks USA]]></content>
         <published>2015-03-18T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Heavy Haul Models at National Show | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-feature-vocational-heavy-haul-models-at-the-national-heavy-equipment-show/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-feature-vocational-heavy-haul-models-at-the-national-heavy-equipment-show/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-feature-vocational-heavy-haul-models-at-the-national-heavy-equipment-show/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-feature-vocational-heavy-haul-models-at-the-national-heavy-equipment-show/"/>
         <updated>2015-02-26T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Heavy Haul Models at National Show | Volvo Trucks USA]]></content>
         <published>2015-02-26T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[2015 Safest North American Fleets | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-recognize-safest-north-american-fleets-with-2015-award/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-recognize-safest-north-american-fleets-with-2015-award/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-recognize-safest-north-american-fleets-with-2015-award/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-recognize-safest-north-american-fleets-with-2015-award/"/>
         <updated>2015-02-25T00:00:00.000Z</updated>
         <content type="html"><![CDATA[2015 Safest North American Fleets | Volvo Trucks USA]]></content>
         <published>2015-02-25T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Choosing A Volvo Truck Powertrain | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/online-tool-helps-volvo-trucks-customers-select-most-efficient-powertrain/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/online-tool-helps-volvo-trucks-customers-select-most-efficient-powertrain/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/online-tool-helps-volvo-trucks-customers-select-most-efficient-powertrain/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/online-tool-helps-volvo-trucks-customers-select-most-efficient-powertrain/"/>
         <updated>2015-02-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Choosing A Volvo Truck Powertrain | Volvo Trucks USA]]></content>
         <published>2015-02-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Reducing Trucker Costs | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-new-maintenance-intervals-reduce-customers-costs/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-new-maintenance-intervals-reduce-customers-costs/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-new-maintenance-intervals-reduce-customers-costs/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-new-maintenance-intervals-reduce-customers-costs/"/>
         <updated>2015-02-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Reducing Trucker Costs | Volvo Trucks USA]]></content>
         <published>2015-02-16T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Connected Vehicle Technologies | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-highlight-connected-vehicle-technologies-fuel-efficiency-at-tmc-2015/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-to-highlight-connected-vehicle-technologies-fuel-efficiency-at-tmc-2015/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-highlight-connected-vehicle-technologies-fuel-efficiency-at-tmc-2015/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-to-highlight-connected-vehicle-technologies-fuel-efficiency-at-tmc-2015/"/>
         <updated>2015-02-11T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Connected Vehicle Technologies | Volvo Trucks USA]]></content>
         <published>2015-02-11T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Military Veterans Truck Financing | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-offers-financing-opportunity-for-returning-us-military-personnel/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-offers-financing-opportunity-for-returning-us-military-personnel/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-offers-financing-opportunity-for-returning-us-military-personnel/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-offers-financing-opportunity-for-returning-us-military-personnel/"/>
         <updated>2015-02-09T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Military Veterans Truck Financing | Volvo Trucks USA]]></content>
         <published>2015-02-09T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[VAH 630 Autohauler Model | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-launches-long-haul-vah-630-autohauler-model/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/february/volvo-trucks-launches-long-haul-vah-630-autohauler-model/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-launches-long-haul-vah-630-autohauler-model/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/february/volvo-trucks-launches-long-haul-vah-630-autohauler-model/"/>
         <updated>2015-02-02T00:00:00.000Z</updated>
         <content type="html"><![CDATA[VAH 630 Autohauler Model | Volvo Trucks USA]]></content>
         <published>2015-02-02T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[Increasing Canadian Market Share | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/january/volvo-trucks-achieves-record-canadian-market-share-in-2014/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/january/volvo-trucks-achieves-record-canadian-market-share-in-2014/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/january/volvo-trucks-achieves-record-canadian-market-share-in-2014/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/january/volvo-trucks-achieves-record-canadian-market-share-in-2014/"/>
         <updated>2015-01-19T00:00:00.000Z</updated>
         <content type="html"><![CDATA[Increasing Canadian Market Share | Volvo Trucks USA]]></content>
         <published>2015-01-19T00:00:00.000Z</published>
     </entry>
     <entry>
         <title type="html"><![CDATA[New River Valley Facility Dedication | Volvo Trucks USA]]></title>
-        <id>https://www.volvotrucks.us//news-and-stories/press-releases/2015/january/volvo-trucks-dedicates-new-vnl-model-at-nrv-facility/</id>
-        <link href="https://www.volvotrucks.us//news-and-stories/press-releases/2015/january/volvo-trucks-dedicates-new-vnl-model-at-nrv-facility/"/>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2015/january/volvo-trucks-dedicates-new-vnl-model-at-nrv-facility/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2015/january/volvo-trucks-dedicates-new-vnl-model-at-nrv-facility/"/>
         <updated>2015-01-16T00:00:00.000Z</updated>
         <content type="html"><![CDATA[New River Valley Facility Dedication | Volvo Trucks USA]]></content>
         <published>2015-01-16T00:00:00.000Z</published>

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -16,7 +16,8 @@ document.addEventListener('click', (e) => {
 });
 
 // OneTrust Cookies Consent Notice start for volvotrucks.us
-if (!window.location.host.includes('hlx.page') && !window.location.host.includes('localhost')) {
+if (!window.location.host.includes('hlx.page') && !window.location.host.includes('localhost') && !window.location.pathname.includes('srcdoc')) {
+  // when running on localhost in the block library host is empty but the path is srcdoc
   // on localhost/hlx.page/hlx.live the consent notice is displayed every time the page opens,
   // because the cookie is not persistent. To avoid this annoyance, disable unless on the
   // production page.

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -409,9 +409,8 @@ export async function loadBlocks(main) {
  * @returns {String} The true origin
  */
 export function getOrigin() {
-  return window.location.href === "about:srcdoc" ? window.location.ancestorOrigins.item(0) : window.location.origin;
+  return window.location.href === 'about:srcdoc' ? window.location.ancestorOrigins.item(0) : window.location.origin;
 }
-
 
 /**
  * Returns a picture element with webp and fallbacks
@@ -557,24 +556,28 @@ export async function waitForLCP(lcpBlocks) {
  * loads a block named 'header' into header
  */
 export function loadHeader(header) {
-  if(header) {
+  if (header) {
     const headerBlock = buildBlock('header', '');
     header.prepend(headerBlock);
     decorateBlock(headerBlock);
-    return loadBlock(headerBlock);  
+    return loadBlock(headerBlock);
   }
+
+  return undefined;
 }
 
 /**
  * loads a block named 'footer' into footer
  */
 export function loadFooter(footer) {
-  if(footer) {
+  if (footer) {
     const footerBlock = buildBlock('footer', '');
     footer.append(footerBlock);
     decorateBlock(footerBlock);
-    return loadBlock(footerBlock);  
+    return loadBlock(footerBlock);
   }
+
+  return undefined;
 }
 
 /**

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -560,10 +560,8 @@ export function loadHeader(header) {
     const headerBlock = buildBlock('header', '');
     header.prepend(headerBlock);
     decorateBlock(headerBlock);
-    return loadBlock(headerBlock);
+    loadBlock(headerBlock);
   }
-
-  return undefined;
 }
 
 /**
@@ -574,10 +572,8 @@ export function loadFooter(footer) {
     const footerBlock = buildBlock('footer', '');
     footer.append(footerBlock);
     decorateBlock(footerBlock);
-    return loadBlock(footerBlock);
+    loadBlock(footerBlock);
   }
-
-  return undefined;
 }
 
 /**

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -409,7 +409,20 @@ export async function loadBlocks(main) {
  * @returns {String} The true origin
  */
 export function getOrigin() {
-  return window.location.href === 'about:srcdoc' ? window.location.ancestorOrigins.item(0) : window.location.origin;
+  return window.location.href === 'about:srcdoc' ? window.parent.location.origin : window.location.origin;
+}
+
+/**
+ * Returns the true href of the current page in the browser.
+ * If the page is running in a iframe with srcdoc,
+ * the ancestor origin + the path query param is returned.
+ * @returns {String} The href of the current page or the href of the block running in the library
+ */
+export function getHref() {
+  if (window.location.href !== 'about:srcdoc') return window.location.href;
+
+  const urlParams = new URLSearchParams(window.parent.location.search);
+  return `${window.parent.location.origin}${urlParams.get('path')}`;
 }
 
 /**
@@ -419,7 +432,7 @@ export function getOrigin() {
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
-  const url = new URL(src, getOrigin());
+  const url = new URL(src, getHref());
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -404,13 +404,23 @@ export async function loadBlocks(main) {
 }
 
 /**
+ * Returns the true origin of the current page in the browser.
+ * If the page is running in a iframe with srcdoc, the ancestor origin is returned.
+ * @returns {String} The true origin
+ */
+export function getOrigin() {
+  return window.location.href === "about:srcdoc" ? window.location.ancestorOrigins.item(0) : window.location.origin;
+}
+
+
+/**
  * Returns a picture element with webp and fallbacks
  * @param {string} src The image URL
  * @param {boolean} eager load image eager
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
-  const url = new URL(src, window.location.href);
+  const url = new URL(src, getOrigin());
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
@@ -547,20 +557,24 @@ export async function waitForLCP(lcpBlocks) {
  * loads a block named 'header' into header
  */
 export function loadHeader(header) {
-  const headerBlock = buildBlock('header', '');
-  header.prepend(headerBlock);
-  decorateBlock(headerBlock);
-  return loadBlock(headerBlock);
+  if(header) {
+    const headerBlock = buildBlock('header', '');
+    header.prepend(headerBlock);
+    decorateBlock(headerBlock);
+    return loadBlock(headerBlock);  
+  }
 }
 
 /**
  * loads a block named 'footer' into footer
  */
 export function loadFooter(footer) {
-  const footerBlock = buildBlock('footer', '');
-  footer.append(footerBlock);
-  decorateBlock(footerBlock);
-  return loadBlock(footerBlock);
+  if(footer) {
+    const footerBlock = buildBlock('footer', '');
+    footer.append(footerBlock);
+    decorateBlock(footerBlock);
+    return loadBlock(footerBlock);  
+  }
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -430,7 +430,7 @@ async function loadLazy(doc) {
   loadHeader(header);
   loadFooter(doc.querySelector('footer'));
 
-  const subnav = header.querySelector('.block.sub-nav');
+  const subnav = header?.querySelector('.block.sub-nav');
   if (subnav) {
     loadBlock(subnav);
   }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,9 +12,7 @@
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
-      "isPalette": true,
-      "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://hlx.live/tools/sidekick/library?base=https://main--vg-volvotrucks-us--hlxsites.hlx.live/block-library/library.json",
+      "url": "https://main--vg-volvotrucks-us--hlxsites.hlx.live/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
     },
     {

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="Description" content="Sidekick Library" />
+    <meta name="robots" content="noindex" />
+    <base href="/" />
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+        background-color: #ededed;
+        height: 100%;
+      }
+    </style>
+    <title>Sidekick Library</title>
+  </head>
+
+  <body>
+    <script
+      type="module"
+      src="https://www.hlx.live/tools/sidekick/library/index.js"
+    ></script>
+    <script>
+      const library = document.createElement('sidekick-library')
+      library.config = {
+        base: '/block-library/library.json',
+      }
+
+      document.body.prepend(library)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Do not merge until https://github.com/adobe/helix-website/pull/275 is merged
This PR migrates the `volvotrucks-us` site to the new full screen version of the sidekick library.

@synox Most blocks worked without change, some required changes due to `window.location.origin` not existing when running in the sidekick library.

Two blocks need to be slightly reworked.

- Calculator
- Engine Specifications

These blocks assume the content to feed them is in the same place as the page itself. It doesn't look like this pattern is going to work. I would suggest to rework these blocks to instead configure them using block config and read in the values using the `readBlockConfig` method from `lib-franklin`.

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://sidekick-library-migration--vg-volvotrucks-us--hlxsites.hlx.page/
