### PR TITLE
fix: hide sidekick when library is open

### DIFF
--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -19,6 +19,8 @@
         background-color: #ededed;
         height: 100%;
       }
+      
+      helix-sidekick { display: none }
     </style>
     <title>Sidekick Library</title>
   </head>
@@ -26,7 +28,7 @@
   <body>
     <script
       type="module"
-      src="https://www.hlx.live/tools/sidekick/library/index.js"
+      src="https://main--franklin-library-host--dylandepass.hlx.live/tools/sidekick/library/index.js"
     ></script>
     <script>
       const library = document.createElement('sidekick-library')

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -28,7 +28,7 @@
   <body>
     <script
       type="module"
-      src="https://main--franklin-library-host--dylandepass.hlx.live/tools/sidekick/library/index.js"
+      src="https://www.hlx.live/tools/sidekick/library/index.js"
     ></script>
     <script>
       const library = document.createElement('sidekick-library')


### PR DESCRIPTION
Forgot some css to hide the sidekick when the library is opened

Test URLs:

Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
After: https://hide-sidekick--vg-volvotrucks-us--hlxsites.hlx.page/
