### PR TITLE
#453 Loading GTM tracking only when user agrees

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -3,7 +3,13 @@ import { loadScript, sampleRUM } from './lib-franklin.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
-loadGoogleTagManager();
+
+const cookieSetting = decodeURIComponent(document.cookie.split(';').find((cookie) => cookie.trim().startsWith('OptanonConsent=')));
+const isGtmAllowed = cookieSetting.includes('C0002:1');
+
+if (isGtmAllowed) {
+  loadGoogleTagManager();
+}
 
 // add more delayed functionality here
 document.addEventListener('click', (e) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #453 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://453-gtm-tracking--vg-volvotrucks-us--hlxsites.hlx.page/
