### PR TITLE
457 fb pixel only trigger if social cookie is on

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -15,31 +15,11 @@ const isPerformanceAllowed = cookieSetting.includes(COOKIES.performance);
 const isSocialAllowed = cookieSetting.includes(COOKIES.social);
 
 if (isPerformanceAllowed) {
-  loadGoogleTagManager(); // facebook pixel is added by gtm too
+  loadGoogleTagManager();
   loadHotjar();
-  if (!isSocialAllowed) {
-    //remove facebook pixel aka fbevents.js
-    const htmlElement = document.querySelector('html');
+}
 
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          if (node.nodeName === 'SCRIPT' && node.src.includes('fbevents.js')) {
-            node.remove();
-            [...document.querySelectorAll('script[id]')]
-              .filter((script) => script.innerHTML.includes('fbevents.js'))[0].remove();
-            [...document.querySelectorAll('noscript')]
-              .filter((script) => script.innerHTML.includes('facebook.com'))[0].remove();
-            console.log('%cRemoved facebook pixel', 'color: #f00');
-            observer.disconnect();
-          }
-        });
-      });
-    });
-
-    observer.observe(htmlElement, { childList: true });
-  }
-} else if (isSocialAllowed) {
+if (isSocialAllowed) {
   loadFacebookPixel();
 }
 


### PR DESCRIPTION
### Main Fix

FB pixel is no longer triggered by GTM, so now only delayed.js will trigger it under the Social Media cookie allowance

#

Fix #457 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/
- After: https://457-fbevents-triggering--vg-volvotrucks-us--hlxsites.hlx.page/
