### PR TITLE
Support AEM Hosted Videos in embed blocks without cookie consent

### DIFF
--- a/head.html
+++ b/head.html
@@ -4,3 +4,4 @@
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">
+<link rel="preconnect" href="https://vjs.zencdn.net"/>

--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -17,10 +17,14 @@ export function selectVideoLink(links, preferredType) {
   const cookieConsentForExternalVideos = optanonConsentCookieValue.includes('C0005:1');
   const shouldUseYouTubeLinks = cookieConsentForExternalVideos && preferredType !== 'local';
   const youTubeLink = linksList.find((link) => link.getAttribute('href').includes('youtube.com/embed/'));
+  const aemHostedLink = linksList.find((link) => link.getAttribute('href').includes('adobeaemcloud.com/adobe/assets/'));
   const localMediaLink = linksList.find((link) => link.getAttribute('href').split('?')[0].endsWith('.mp4'));
 
   if (shouldUseYouTubeLinks && youTubeLink) {
     return youTubeLink;
+  }
+  if (aemHostedLink) {
+    return aemHostedLink;
   }
   return localMediaLink;
 }


### PR DESCRIPTION
Fix #516

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.hlx.live/all-new-vnl/test
- After: https://test-aem-videos--vg-volvotrucks-us--hlxsites.hlx.live/all-new-vnl/test
