### PR TITLE
fix: workaround for filter options in AEM Assets Sidekick Plugin

### DIFF
--- a/news-and-stories/press-releases/feed.xml
+++ b/news-and-stories/press-releases/feed.xml
@@ -2,10 +2,18 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://www.volvotrucks.us/news-and-stories/press-releases/</id>
     <title>Volvo Trucks USA Press Releases</title>
-    <updated>2024-07-08T00:00:00.000Z</updated>
+    <updated>2024-07-10T00:00:00.000Z</updated>
     <generator>AEM News feed generator (GitHub action)</generator>
     <link rel="alternate" href="https://www.volvotrucks.us/news-and-stories/press-releases/"/>
     <subtitle>Volvo Trucks USA Press Releases</subtitle>
+    <entry>
+        <title type="html"><![CDATA[Volvo Trucks Celebrates First Order of the All-New Volvo VNL in Canada by Tobler and Sons Inc.]]></title>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/volvo-trucks-celebrates-first-order-of-the-all-new-volvo-vnl-in-canada-by-tobler-and-sons-inc/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/volvo-trucks-celebrates-first-order-of-the-all-new-volvo-vnl-in-canada-by-tobler-and-sons-inc/"/>
+        <updated>2024-07-10T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[“These events at NRV have given us a fantastic opportunity to engage with our customers and witness their excitement about the all-new Volvo VNL,” said Matthew Blackman, managing director for Canada, Volvo Trucks North America.]]></content>
+        <published>2024-07-10T00:00:00.000Z</published>
+    </entry>
     <entry>
         <title type="html"><![CDATA[North American Teams Head to Sweden for Volvo Trucks Global Service Training Award Championship]]></title>
         <id>https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/north-american-teams-head-to-sweden-for-volvo-trucks-global-service-training-award-championship/</id>

--- a/news-and-stories/press-releases/feed.xml
+++ b/news-and-stories/press-releases/feed.xml
@@ -2,10 +2,18 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://www.volvotrucks.us/news-and-stories/press-releases/</id>
     <title>Volvo Trucks USA Press Releases</title>
-    <updated>2024-07-01T00:00:00.000Z</updated>
+    <updated>2024-07-08T00:00:00.000Z</updated>
     <generator>AEM News feed generator (GitHub action)</generator>
     <link rel="alternate" href="https://www.volvotrucks.us/news-and-stories/press-releases/"/>
     <subtitle>Volvo Trucks USA Press Releases</subtitle>
+    <entry>
+        <title type="html"><![CDATA[North American Teams Head to Sweden for Volvo Trucks Global Service Training Award Championship]]></title>
+        <id>https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/north-american-teams-head-to-sweden-for-volvo-trucks-global-service-training-award-championship/</id>
+        <link href="https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/north-american-teams-head-to-sweden-for-volvo-trucks-global-service-training-award-championship/"/>
+        <updated>2024-07-08T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[“VISTA is not just a competition; it’s a tradition and a testament to the skills, dedication, and excellence of Volvo’s service personnel worldwide. It provides an unparalleled opportunity for teams to connect, learn, and improve, ultimately enhancing the quality of service and innovation within the industry,” said Steve Parkins, vice president, competence development, Volvo Trucks North America]]></content>
+        <published>2024-07-08T00:00:00.000Z</published>
+    </entry>
     <entry>
         <title type="html"><![CDATA[Volvo Trucks North America Customer Hight Logistics Expands All-Electric, Zero-Emission Fleet]]></title>
         <id>https://www.volvotrucks.us/news-and-stories/press-releases/2024/july/volvo-trucks-north-america-customer-hight-logistics-expands-all-electric-zero-emission-fleet/</id>

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -27,7 +27,7 @@
       "environments": [
         "edit"
       ],
-      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html?extConfigUrl=https://helix-asset-selector-configs.netlify.app/config.json",
       "isPalette": true,
       "includePaths": [
         "**.docx**"


### PR DESCRIPTION
Fix #668 

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/
- After: https://asset-filter-fix--vg-volvotrucks-us--hlxsites.aem.page/
