### PR TITLE
Article cards 1 and 2 link variations #619

### DIFF
--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -68,8 +68,6 @@
 
   .v2-article-cards__texts-wrapper {
     --v2-article-cards-padding: 24px;
-
-    min-height: 200px;
   }
 
   .v2-article-cards__card-date {

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -1,0 +1,160 @@
+:root {
+  --v2-article-cards-gutter: 16px;
+  --v2-article-cards-padding: 24px;
+  --v2-article-cards-text-gutter: 8px;
+  --v2-article-cards-border-radius: 8px;
+}
+
+.v2-article-cards__article-list {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin: 0;
+  gap: var(--v2-article-cards-gutter);
+}
+
+.v2-article-cards__article {
+  list-style: none;
+  border-radius: var(--v2-article-cards-border-radius);
+}
+
+.v2-article-cards__image-wrapper {
+  display: block;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.v2-article-cards__image-wrapper img {
+  object-fit: cover;
+  height: 100%;
+  border-radius: var(--v2-article-cards-border-radius)
+    var(--v2-article-cards-border-radius) 0 0;
+}
+
+.v2-article-cards__texts-wrapper {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--card-background);
+  padding: var(--v2-article-cards-padding);
+  gap: var(--v2-article-cards-text-gutter);
+  border-radius: 0 0 var(--v2-article-cards-border-radius)
+    var(--v2-article-cards-border-radius);
+}
+
+.v2-article-cards__texts-wrapper * {
+  margin: 0;
+}
+
+.v2-article-cards__texts-wrapper .v2-article-cards__card-date {
+  font-size: var(--f-body-2-font-size);
+}
+
+.v2-article-cards__texts-wrapper .v2-article-cards__card-heading {
+  font-size: var(--f-heading-5-font-size);
+}
+
+.v2-article-cards__texts-wrapper .v2-article-cards__card-button {
+  padding: 8px 12px 8px 0;
+}
+
+@media screen and (min-width: 744px) {
+  .v2-article-cards__article-list {
+    --v2-article-cards-gutter: 20px;
+
+    flex-flow: row wrap;
+    justify-content: space-between;
+    max-width: var(--wrapper-width);
+  }
+
+  .v2-article-cards__texts-wrapper {
+    --v2-article-cards-padding: 24px;
+
+    min-height: 200px;
+  }
+
+  .v2-article-cards__card-date {
+    font-size: var(--f-body-2-font-size);
+  }
+
+  .v2-article-cards__card-heading {
+    font-size: var(--f-heading-5-font-size);
+  }
+
+  .v2-article-cards__card-button {
+    padding: 8px 12px 8px 0;
+  }
+
+  .v2-article-cards__article {
+    max-width: calc(
+      (var(--wrapper-width) - (var(--v2-article-cards-gutter) * 2)) / 3
+    );
+    width: 100%;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper,
+  .v2-article-cards--2-articles .v2-article-cards__texts-wrapper {
+    --v2-article-cards-padding: 32px 48px;
+    --v2-article-cards-text-gutter: 16px;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__card-date,
+  .v2-article-cards--2-articles .v2-article-cards__card-date {
+    font-size: var(--f-heading-5-font-size);
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__card-heading,
+  .v2-article-cards--2-articles .v2-article-cards__card-heading {
+    font-size: var(--f-heading-4-font-size);
+  }
+
+  .v2-article-cards--2-articles.v2-article-cards__article-list {
+    --v2-article-cards-gutter: 20px;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__article {
+    display: flex;
+    flex-flow: row-reverse;
+    max-width: unset;
+    max-height: 510px;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper {
+    width: calc(var(--wrapper-width) * 0.55);
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper img {
+    border-radius: 0 var(--v2-article-cards-border-radius)
+      var(--v2-article-cards-border-radius) 0;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
+    width: calc(var(--wrapper-width) * 0.45);
+    justify-content: center;
+    border-radius: var(--v2-article-cards-border-radius) 0 0
+      var(--v2-article-cards-border-radius);
+  }
+
+  .v2-article-cards--2-articles .v2-article-cards__article {
+    max-width: calc(
+      (var(--wrapper-width) - var(--v2-article-cards-gutter)) / 2
+    );
+    width: 100%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .v2-article-cards__article-list {
+    --v2-article-cards-gutter: 70px;
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper {
+    width: calc(var(--wrapper-width) * 0.7);
+  }
+
+  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
+    width: calc(var(--wrapper-width) * 0.3);
+    justify-content: center;
+    border-radius: var(--v2-article-cards-border-radius) 0 0
+      var(--v2-article-cards-border-radius);
+  }
+}

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -5,6 +5,10 @@
   --v2-article-cards-border-radius: 8px;
 }
 
+.v2-article-cards-wrapper {
+  --section-div-padding: 16px
+}
+
 .v2-article-cards__article-list {
   display: flex;
   flex-direction: column;
@@ -13,10 +17,14 @@
   gap: var(--v2-article-cards-gutter);
 }
 
-.v2-article-cards__article {
+.v2-article-cards__article-card {
   background-color: var(--card-background);
   list-style: none;
   border-radius: var(--v2-article-cards-border-radius);
+}
+
+.v2-article-cards__article-card:hover .v2-article-cards__card-button a {
+  text-decoration: underline;
 }
 
 .v2-article-cards__image-wrapper {
@@ -43,10 +51,12 @@
 }
 
 .v2-article-cards__texts-wrapper .v2-article-cards__card-date {
+  color: var(--text-color);
   font-size: var(--f-body-2-font-size);
 }
 
 .v2-article-cards__texts-wrapper .v2-article-cards__card-heading {
+  color: var(--text-color);
   font-size: var(--f-heading-5-font-size);
 }
 
@@ -54,7 +64,11 @@
   padding: 8px 12px 8px 0;
 }
 
-@media screen and (min-width: 744px) {
+@media (min-width: 744px) {
+  .v2-article-cards-wrapper {
+    --section-div-padding: 24px 32px
+  }
+
   .v2-article-cards__article-list {
     --v2-article-cards-gutter: 20px;
 
@@ -79,7 +93,7 @@
     padding: 8px 12px 8px 0;
   }
 
-  .v2-article-cards__article {
+  .v2-article-cards__article-card {
     max-width: calc(
       (var(--wrapper-width) - (var(--v2-article-cards-gutter) * 2)) / 3
     );
@@ -87,18 +101,21 @@
   }
 
   .v2-article-cards--1-articles .v2-article-cards__texts-wrapper,
-  .v2-article-cards--2-articles .v2-article-cards__texts-wrapper {
+  .v2-article-cards--2-articles .v2-article-cards__texts-wrapper,
+  .v2-article-cards--3-articles .v2-article-cards__texts-wrapper {
     --v2-article-cards-padding: 32px 48px;
     --v2-article-cards-text-gutter: 16px;
   }
 
   .v2-article-cards--1-articles .v2-article-cards__card-date,
-  .v2-article-cards--2-articles .v2-article-cards__card-date {
+  .v2-article-cards--2-articles .v2-article-cards__card-date,
+  .v2-article-cards--3-articles .v2-article-cards__card-date {
     font-size: var(--f-heading-5-font-size);
   }
 
   .v2-article-cards--1-articles .v2-article-cards__card-heading,
-  .v2-article-cards--2-articles .v2-article-cards__card-heading {
+  .v2-article-cards--2-articles .v2-article-cards__card-heading,
+  .v2-article-cards--3-articles .v2-article-cards__card-heading {
     font-size: var(--f-heading-4-font-size);
   }
 
@@ -106,28 +123,34 @@
     --v2-article-cards-gutter: 20px;
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__article {
+  .v2-article-cards--1-articles .v2-article-cards__article-card,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type {
     display: flex;
     flex-flow: row-reverse;
     max-width: unset;
     max-height: 510px;
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__image-wrapper {
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type .v2-article-cards__image-wrapper {
     width: calc(var(--wrapper-width) * 0.55);
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__image-wrapper img {
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper img,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type .v2-article-cards__image-wrapper img {
     border-radius: 0 var(--v2-article-cards-border-radius)
       var(--v2-article-cards-border-radius) 0;
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
+  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type .v2-article-cards__texts-wrapper {
     width: calc(var(--wrapper-width) * 0.45);
     justify-content: center;
   }
 
-  .v2-article-cards--2-articles .v2-article-cards__article {
+  /* stylelint-disable-next-line no-descending-specificity */
+  .v2-article-cards--2-articles .v2-article-cards__article-card,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:not(.v2-article-cards__article-card:first-of-type) {
     max-width: calc(
       (var(--wrapper-width) - var(--v2-article-cards-gutter)) / 2
     );
@@ -136,15 +159,21 @@
 }
 
 @media (min-width: 1200px) {
-  .v2-article-cards__article-list {
+  .v2-article-cards-wrapper {
+    --section-div-padding: 40px 0
+  }
+
+  .v2-article-cards__article-list.v2-article-cards--dynamic-articles{
     --v2-article-cards-gutter: 70px;
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__image-wrapper {
+  .v2-article-cards--1-articles .v2-article-cards__image-wrapper,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type .v2-article-cards__image-wrapper {
     width: calc(var(--wrapper-width) * 0.7);
   }
 
-  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
+  .v2-article-cards--1-articles .v2-article-cards__texts-wrapper,
+  .v2-article-cards--3-articles .v2-article-cards__article-card:first-of-type .v2-article-cards__texts-wrapper {
     width: calc(var(--wrapper-width) * 0.3);
     justify-content: center;
   }

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -14,6 +14,7 @@
 }
 
 .v2-article-cards__article {
+  background-color: var(--card-background);
   list-style: none;
   border-radius: var(--v2-article-cards-border-radius);
 }
@@ -34,7 +35,6 @@
 .v2-article-cards__texts-wrapper {
   display: flex;
   flex-direction: column;
-  background-color: var(--card-background);
   padding: var(--v2-article-cards-padding);
   gap: var(--v2-article-cards-text-gutter);
   border-radius: 0 0 var(--v2-article-cards-border-radius)

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -22,7 +22,6 @@
 .v2-article-cards__image-wrapper {
   display: block;
   aspect-ratio: 4 / 3;
-  object-fit: cover;
 }
 
 .v2-article-cards__image-wrapper img {

--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -37,8 +37,6 @@
   flex-direction: column;
   padding: var(--v2-article-cards-padding);
   gap: var(--v2-article-cards-text-gutter);
-  border-radius: 0 0 var(--v2-article-cards-border-radius)
-    var(--v2-article-cards-border-radius);
 }
 
 .v2-article-cards__texts-wrapper * {
@@ -128,8 +126,6 @@
   .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
     width: calc(var(--wrapper-width) * 0.45);
     justify-content: center;
-    border-radius: var(--v2-article-cards-border-radius) 0 0
-      var(--v2-article-cards-border-radius);
   }
 
   .v2-article-cards--2-articles .v2-article-cards__article {
@@ -152,7 +148,5 @@
   .v2-article-cards--1-articles .v2-article-cards__texts-wrapper {
     width: calc(var(--wrapper-width) * 0.3);
     justify-content: center;
-    border-radius: var(--v2-article-cards-border-radius) 0 0
-      var(--v2-article-cards-border-radius);
   }
 }

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -47,7 +47,7 @@ const createCard = (article) => {
   } else {
     const newButton = createElement('a', { classes: `${blockName}__card-button` });
     newButton.href = path;
-    newButton.textContent = getTextLabel('readMore');
+    newButton.textContent = getTextLabel('readMoreBtn');
     textWrapper.appendChild(newButton);
   }
   card.appendChild(cardContent);

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -11,6 +11,7 @@ import {
 } from '../../scripts/aem.js';
 
 const blockName = 'v2-article-cards';
+const indexUrl = new URL(`${getLanguagePath()}magazine-articles.json`, getOrigin());
 
 const createCard = (article) => {
   const {
@@ -45,8 +46,7 @@ const createCard = (article) => {
     button.classList.add(`${blockName}__card-button`);
     textWrapper.appendChild(button);
   } else {
-    const newButton = createElement('a', { classes: `${blockName}__card-button` });
-    newButton.href = path;
+    const newButton = createElement('a', { classes: `${blockName}__card-button`, props: { href: path } });
     newButton.textContent = getTextLabel('readMoreBtn');
     textWrapper.appendChild(newButton);
   }
@@ -65,7 +65,6 @@ const createArticleCards = (block, articles, amount = null) => {
 };
 
 export default async function decorate(block) {
-  const indexUrl = new URL(`${getLanguagePath()}magazine-articles.json`, getOrigin());
   const allArticles = await getJsonFromUrl(indexUrl);
   const amountOfLinks = block.children.length;
 
@@ -74,9 +73,9 @@ export default async function decorate(block) {
   if (amountOfLinks !== 0) {
     const buttons = block.querySelectorAll('.button-container');
     buttons.forEach((a) => {
-      const link = a.querySelector('a').href;
+      const link = a.querySelector('a')?.href;
       [...allArticles.data].forEach((el) => {
-        if (link.includes(el.path)) {
+        if (link?.includes(el.path)) {
           el.button = a;
           selectedArticles.push(el);
         }

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -23,30 +23,30 @@ const createCard = (article) => {
   } = article;
 
   const shortTitle = title.split('|')[0];
-  const card = createElement('article', { classes: `${blockName}__article` });
+  const card = createElement('a', { classes: `${blockName}__article-card`, props: { href: path } });
   const picture = createOptimizedPicture(image, shortTitle, false, [{ width: '380', height: '214' }]);
   const pictureTag = picture.outerHTML;
   const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
   const cardContent = document.createRange().createContextualFragment(`
-          <a href="${path}" class="${blockName}__image-wrapper">
-              ${pictureTag}
-          </a>
-          <div class="${blockName}__texts-wrapper">
-              <p class="${blockName}__card-date">
-                  ${date.toLocaleDateString()}
-              </p>
-              <h4 class="${blockName}__card-heading">
-                  ${shortTitle}
-              </h4>
-          </div>
-        `);
+    <div class="${blockName}__image-wrapper">
+        ${pictureTag}
+    </div>
+    <div class="${blockName}__texts-wrapper">
+        <p class="${blockName}__card-date">
+            ${date.toLocaleDateString()}
+        </p>
+        <h4 class="${blockName}__card-heading">
+            ${shortTitle}
+        </h4>
+    </div>
+  `);
   const textWrapper = cardContent.querySelector(`.${blockName}__texts-wrapper`);
 
   if (button) {
     button.classList.add(`${blockName}__card-button`);
     textWrapper.appendChild(button);
   } else {
-    const newButton = createElement('a', { classes: `${blockName}__card-button`, props: { href: path } });
+    const newButton = createElement('a', { classes: `${blockName}__card-button` });
     newButton.textContent = getTextLabel('readMoreBtn');
     textWrapper.appendChild(newButton);
   }
@@ -61,7 +61,11 @@ const createArticleCards = (block, articles, amount = null) => {
     articleList.append(card);
   });
   block.append(articleList);
-  if (amount) articleList.classList.add(`${blockName}--${amount}-articles`);
+  if (amount) {
+    articleList.classList.add(`${blockName}--${amount}-articles`);
+  } else {
+    articleList.classList.add(`${blockName}--dynamic-articles`);
+  }
 };
 
 export default async function decorate(block) {

--- a/blocks/v2-article-cards/v2-article-cards.js
+++ b/blocks/v2-article-cards/v2-article-cards.js
@@ -1,0 +1,95 @@
+import {
+  getJsonFromUrl,
+  getLanguagePath,
+  getOrigin,
+  createElement,
+  unwrapDivs,
+  getTextLabel,
+} from '../../scripts/common.js';
+import {
+  createOptimizedPicture,
+} from '../../scripts/aem.js';
+
+const blockName = 'v2-article-cards';
+
+const createCard = (article) => {
+  const {
+    path,
+    image,
+    title,
+    publishDate,
+    button = false,
+  } = article;
+
+  const shortTitle = title.split('|')[0];
+  const card = createElement('article', { classes: `${blockName}__article` });
+  const picture = createOptimizedPicture(image, shortTitle, false, [{ width: '380', height: '214' }]);
+  const pictureTag = picture.outerHTML;
+  const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
+  const cardContent = document.createRange().createContextualFragment(`
+          <a href="${path}" class="${blockName}__image-wrapper">
+              ${pictureTag}
+          </a>
+          <div class="${blockName}__texts-wrapper">
+              <p class="${blockName}__card-date">
+                  ${date.toLocaleDateString()}
+              </p>
+              <h4 class="${blockName}__card-heading">
+                  ${shortTitle}
+              </h4>
+          </div>
+        `);
+  const textWrapper = cardContent.querySelector(`.${blockName}__texts-wrapper`);
+
+  if (button) {
+    button.classList.add(`${blockName}__card-button`);
+    textWrapper.appendChild(button);
+  } else {
+    const newButton = createElement('a', { classes: `${blockName}__card-button` });
+    newButton.href = path;
+    newButton.textContent = getTextLabel('readMore');
+    textWrapper.appendChild(newButton);
+  }
+  card.appendChild(cardContent);
+  return card;
+};
+
+const createArticleCards = (block, articles, amount = null) => {
+  const articleList = createElement('div', { classes: `${blockName}__article-list` });
+  articles.forEach((art) => {
+    const card = createCard(art);
+    articleList.append(card);
+  });
+  block.append(articleList);
+  if (amount) articleList.classList.add(`${blockName}--${amount}-articles`);
+};
+
+export default async function decorate(block) {
+  const indexUrl = new URL(`${getLanguagePath()}magazine-articles.json`, getOrigin());
+  const allArticles = await getJsonFromUrl(indexUrl);
+  const amountOfLinks = block.children.length;
+
+  const selectedArticles = [];
+
+  if (amountOfLinks !== 0) {
+    const buttons = block.querySelectorAll('.button-container');
+    buttons.forEach((a) => {
+      const link = a.querySelector('a').href;
+      [...allArticles.data].forEach((el) => {
+        if (link.includes(el.path)) {
+          el.button = a;
+          selectedArticles.push(el);
+        }
+      });
+    });
+  }
+
+  if (selectedArticles.length > 0) {
+    createArticleCards(block, selectedArticles, amountOfLinks);
+  } else {
+    // TODO here goes the logic to build the full article list
+    const sortedArticles = allArticles.data.sort((a, b) => a.date > b.date);
+    createArticleCards(block, sortedArticles);
+  }
+  unwrapDivs(block);
+}

--- a/placeholder.json
+++ b/placeholder.json
@@ -322,6 +322,10 @@
     {
       "Key": "readTime",
       "Text": "read"
+    },
+    {
+      "Key": "readMoreBtn",
+      "Text": "Read More"
     }
   ],
   ":type": "sheet"


### PR DESCRIPTION
Fix #619

Created the variants where the author adds the link and the text of the button. The styles depend on the amount of links added. For 1, 2 and 3 links per block.
The rest comes from matching the link with the metadata from the articles. 

[Figma](https://www.figma.com/design/c2jG1bOcvle2bCmZqgptyS/Magazine-C%26T?node-id=1569-17870&m=dev)

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/drafts/shomps/v2-article-cards
- After: https://619-article-cards--vg-volvotrucks-us--hlxsites.aem.page/drafts/shomps/v2-article-cards
