### PR TITLE
Blank page displayed when clicked on Explore safety link for the second time #698

### DIFF
--- a/common/modal/modal.js
+++ b/common/modal/modal.js
@@ -4,7 +4,7 @@ import {
   decorateIcons,
   getTextLabel,
 } from '../../scripts/common.js';
-import { loadCSS } from '../../scripts/aem.js';
+import { loadCSS, updateSectionsStatus } from '../../scripts/aem.js';
 import {
   AEM_ASSETS,
   createIframe,
@@ -95,6 +95,12 @@ const createModal = () => {
     modalBackground.querySelector('.modal-top-bar-heading').textContent = '';
   };
 
+  const handleVideoLoad = (videoElement) => {
+    videoElement.addEventListener('loadeddata', () => {
+      updateSectionsStatus(modalContent);
+    }, { once: true });
+  };
+
   const handleNewContent = (newContent) => {
     clearModalContent();
     modalContent.scrollTo(0, 0);
@@ -118,6 +124,9 @@ const createModal = () => {
 
     modalContent.classList.add('modal-content--wide');
     modalContent.append(...newContent);
+
+    const videoElements = modalContent.querySelectorAll('video');
+    videoElements.forEach(handleVideoLoad);
   };
 
   async function showModal(newContent, {


### PR DESCRIPTION
Fix https://github.com/hlxsites/vg-volvotrucks-us/issues/698

Test URLs:

Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/trucks/all-new-vnl/#safety
After: https://698-modal-content-visibility--vg-volvotrucks-us--hlxsites.aem.page/trucks/all-new-vnl/#safety

The issue was that section gets stuck on its loading status, which hides its content before it is loaded, supposedly to prevent the flash of un-styled content (FOUC)

The fix is based on re-checking the section status when the video has been loaded. There is a bit of delay before video shows up after modal is closed and re-opened. This is expected behavior.

Previous PR was approved but accidentally merged to main, sorry for the oversight :(

