### PR TITLE
532 - add magazines metadata to search

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -170,7 +170,7 @@ indices:
       image:
         select: head > meta[property="og:image"]
         value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
-      readingTime:
+      readTime:
         select: head > meta[name="readingtime"]
         value: attribute(el, "content")
       publishDate:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -158,12 +158,24 @@ indices:
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
+      author:
+        select: head > meta[name="author"]
+        value: attribute(el, "content")
       category:
         select: head > meta[name="category"]
         value: attribute(el, "content")
       tags:
         select: head > meta[property="article:tag"]
         values: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      readingTime:
+        select: head > meta[name="readingtime"]
+        value: attribute(el, "content")
+      publishDate:
+        select: head > meta[name="publish-date"]
+        value: parseTimestamp(attribute(el, "content"), MM/DD/YYYY)
       text:
         select: main
         value: textContent(el)


### PR DESCRIPTION
Add missing fields from magazines to search
 
Fix #532

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/
- After: https://532-fr-volvo-trucks-magazine-search-filter-tags--vg-volvotrucks-us--hlxsites.aem.page/
