### PR TITLE
688 search using endpoint

### DIFF
--- a/blocks/magazine-articles/magazine-articles.css
+++ b/blocks/magazine-articles/magazine-articles.css
@@ -1,304 +1,325 @@
 /* Filter magazine articles */
 .block.magazine-articles .list-filter {
-    background-color: var(--volvo-text-gray);
-    padding: 25px;
-    margin: 0 0 24px;
+  background-color: var(--volvo-text-gray);
+  padding: 25px;
+  margin: 0 0 24px;
 }
 
 .block.magazine-articles .list-filter input,
 .block.magazine-articles .list-filter select {
-    font-family: var(--ff-volvo-novum);
-    font-size: 1.6rem;
-    background-color: var(--c-white);
-    width: 100%;
-    margin-top: 1rem;
-    max-width: unset;
+  font-family: var(--ff-volvo-novum);
+  font-size: 1.6rem;
+  background-color: var(--c-white);
+  width: 100%;
+  margin-top: 1rem;
+  max-width: unset;
 }
 
 .magazine-articles-wrapper > div {
-    margin: 48px auto;
+  margin: 48px auto;
 }
 
 .block.magazine-articles .list-filter fieldset {
-    border: 0;
+  border: 0;
 }
 
 .block.magazine-articles .list-filter fieldset div {
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    flex-grow: 1;
-    max-width: 100%;
-    margin: 0 15px;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  max-width: 100%;
+  margin: 0 15px;
 }
 
 .block.magazine-articles .search-field {
-    position: relative;
+  position: relative;
 }
 
 .block.magazine-articles .search-field button {
-    right: 1rem;
-    top: .8rem;
-    width: 2.6rem;
-    height: 2.6rem;
-    border-radius: 0.3rem;
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    background-color: transparent;
-    border: 0;
+  right: 1rem;
+  top: 0.8rem;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 0.3rem;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  background-color: transparent;
+  border: 0;
 }
 
 .block.magazine-articles .pager {
-    font-size: 1.4rem;
-    display: grid;
-    margin: 1em 0;
-    grid-template-columns: repeat(2, 1fr);
+  font-size: 1.4rem;
+  display: grid;
+  margin: 1em 0;
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .block.magazine-articles .category-field,
 .block.magazine-articles .topic-field,
-.block.magazine-articles .truck-field   {
-    display: block;
-    position: relative;
-    grid-template-columns: 1fr 68%;
-    align-items: center;
-    margin-bottom: 0.75em;
+.block.magazine-articles .truck-field {
+  display: block;
+  position: relative;
+  grid-template-columns: 1fr 68%;
+  align-items: center;
+  margin-bottom: 0.75em;
 }
 
 .block.magazine-articles .category-field::after,
 .block.magazine-articles .topic-field::after,
-.block.magazine-articles .truck-field::after  {
-    font-family: var(--ff-fontawesome);
-    color: var(--volvo-text-gray);
-    content: "\f107";
-    position: absolute;
-    display: inline-block;
-    right: 15px;
-    top: 5px;
-    bottom: 0;
-    font-size: 2.4rem;
-    pointer-events: none;
+.block.magazine-articles .truck-field::after {
+  font-family: var(--ff-fontawesome);
+  color: var(--volvo-text-gray);
+  content: "\f107";
+  position: absolute;
+  display: inline-block;
+  right: 15px;
+  top: 5px;
+  bottom: 0;
+  font-size: 2.4rem;
+  pointer-events: none;
 }
 
 /* Latest magazine articles */
 .block.latest .latest-magazine-articles article .content h3 a {
-    color: var(--c-cta-blue-default);
-    font-weight: 700;
-    border: none;
-    padding: 0;
+  color: var(--c-cta-blue-default);
+  font-weight: 700;
+  border: none;
+  padding: 0;
 }
 
 .block .latest-magazine-articles {
-    display: unset;
+  display: unset;
 }
 
 .block .latest-magazine-articles article {
-    margin-top: 24px;
+  margin-top: 24px;
 }
 
 .block .latest-magazine-articles article:first-child {
-    margin-top: -24px;
+  margin-top: -24px;
 }
 
 .block .latest-magazine-articles > article img,
 .block .latest-magazine-articles > article source {
-    display: block;
-    height: auto;
-    border: 0;
-    object-fit: cover;
+  display: block;
+  height: auto;
+  border: 0;
+  object-fit: cover;
 }
 
 .block .latest-magazine-articles .content h3 {
-    margin-bottom: 10px;
-    font-family: var(--ff-volvo-novum-medium);
-    letter-spacing: -.1px;
-    color: var(--volvo-text-gray);
-    margin-top: 24px;
-    font-weight: 400;
-    line-height: 32px;
-    position: relative;
-    text-rendering: optimizelegibility;
+  margin-bottom: 10px;
+  font-family: var(--ff-volvo-novum-medium);
+  letter-spacing: -0.1px;
+  color: var(--volvo-text-gray);
+  margin-top: 24px;
+  font-weight: 400;
+  line-height: 32px;
+  position: relative;
+  text-rendering: optimizelegibility;
 }
 
 .block .latest-magazine-articles .content p {
-    font-size: 13px;
-    position: relative;
-    margin: 0;
-    letter-spacing: -.1px;
-    font-weight: 400;
+  font-size: 13px;
+  position: relative;
+  margin: 0;
+  letter-spacing: -0.1px;
+  font-weight: 400;
 }
 
 /* Magazine articles */
 
 .block.magazine-articles .article-list article {
-    display: block;
-    padding: 1.5em 0;
-    border-top: 1px solid var(--background-light-gray);
+  display: block;
+  padding: 1.5em 0;
+  border-top: 1px solid var(--background-light-gray);
 }
 
 .section.magazine-articles-container > div > div > div.articles > article:nth-child(1) {
-    border-top: 1px solid var(--background-light-gray);
+  border-top: 1px solid var(--background-light-gray);
 }
 
 .block.magazine-articles article a.imgcover {
-    float: unset;
-    position: relative;
-    z-index: 50;
-    height: 250px;
-    display: block;
+  float: unset;
+  position: relative;
+  z-index: 50;
+  height: 250px;
+  display: block;
 }
 
 .block.magazine-articles article picture img {
-    margin-bottom: 16px;
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
+  margin-bottom: 16px;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.block.magazine-articles article picture.default-image img {
+  aspect-ratio: 16/9;
+  object-fit: contain;
 }
 
 .block.magazine-articles .article-list article h3 {
-    margin-top: 24px;
-    margin-bottom: 16px;
-    display: table;
-    font-family: var(--ff-volvo-novum-medium);
-    letter-spacing: -.1px!important;
-    color: var(--volvo-text-gray);
+  margin-top: 24px;
+  margin-bottom: 16px;
+  display: table;
+  font-family: var(--ff-volvo-novum-medium);
+  letter-spacing: -0.1px !important;
+  color: var(--volvo-text-gray);
 }
 
 .block.magazine-articles .article-list article .content {
-    position: relative;
-    min-height: 1px;
-    padding-right: 15px;
-    clear: none;
-    width: 75%;
+  position: relative;
+  min-height: 1px;
+  padding-right: 15px;
+  clear: none;
+  width: 75%;
 }
 
 .block.magazine-articles .article-list article p {
-    margin-top: unset;
-    margin-bottom: 8px;
+  margin-top: unset;
+  margin-bottom: 8px;
 }
 
 .block.magazine-articles article ul {
-    list-style-type: none;
-    padding-left: 0;
-    font-size: 12px;
+  list-style-type: none;
+  padding-left: 0;
+  font-size: 12px;
 }
 
-.block.magazine-articles article .content ul li{
-    display: inline;
+.block.magazine-articles article .content ul li {
+  display: inline;
 }
 
-.block.magazine-articles article .content  ul li:nth-child(2) {
-    color: var(--highlight-background-color);
+.block.magazine-articles article .content ul li:nth-child(2) {
+  color: var(--highlight-background-color);
 }
 
-.block.magazine-articles article .content  ul li+li::before {
-    content: " | ";
-    padding: 0 5px;
+.block.magazine-articles article .content ul li + li::before {
+  content: " | ";
+  padding: 0 5px;
 }
 
 .block.magazine-articles .article-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .cta {
-    display: inline-block;
-    margin-bottom: 0;
-    font-weight: 700;
-    text-align: center;
-    vertical-align: middle;
-    touch-action: manipulation;
-    cursor: pointer;
-    white-space: nowrap;
-    font-size: 16px;
-    line-height: 1.5;
-    border-radius: 0;
-    user-select: none;
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: 700;
+  text-align: center;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 16px;
+  line-height: 1.5;
+  border-radius: 0;
+  user-select: none;
 }
 
 @media screen and (min-width: 768px) {
-    .block.magazine-articles .search-field button {
-        top: 1.8rem;
-    }
+  .block.magazine-articles .search-field button {
+    top: 1.8rem;
+  }
 
-    .block .latest-magazine-articles {
-        display: flex;
-        margin: 0 -15px;
-    }
+  .block .latest-magazine-articles {
+    display: flex;
+    margin: 0 -15px;
+  }
 
-    .block .latest-magazine-articles article {
-        position: relative;
-        min-height: 1px;
-        padding-left: 15px;
-        padding-right: 15px;
-        width: 33.3333%;
-    }
+  .block .latest-magazine-articles article {
+    position: relative;
+    min-height: 1px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 33.3333%;
+  }
 
-    .block .latest-magazine-articles article:first-child {
-        margin-top: 24px;
-    }
+  .block .latest-magazine-articles article:first-child {
+    margin-top: 24px;
+  }
 
-    .block.magazine-articles .list-filter fieldset {
-        display: flex;
-        flex-wrap: wrap;
-        margin: 25px;
-    }
+  .block.magazine-articles .list-filter fieldset {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 25px;
+  }
 
-    .block.magazine-articles .list-filter fieldset div {
-        flex: 1 1 auto;
-        margin: 0 15px;
-    }
+  .block.magazine-articles .list-filter fieldset div {
+    flex: 1 1 auto;
+    margin: 0 15px;
+  }
 
-    /* make sure the fields have the same width when stacked */
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(odd) { min-width: 294px; }
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(even) { min-width: 239px; }
+  /* make sure the fields have the same width when stacked */
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(odd) {
+    min-width: 294px;
+  }
 
-    .block.magazine-articles .category-field::after,
-    .block.magazine-articles .topic-field::after,
-    .block.magazine-articles .truck-field::after  {
-        top: 15px;
-    }
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
+    min-width: 239px;
+  }
+
+  .block.magazine-articles .category-field::after,
+  .block.magazine-articles .topic-field::after,
+  .block.magazine-articles .truck-field::after {
+    top: 15px;
+  }
 }
 
 @media screen and (min-width: 992px) {
-    .block .latest-magazine-articles article,
-    .block .related-magazine-articles article {
-        display: unset;
-    }
+  .block .latest-magazine-articles article,
+  .block .related-magazine-articles article {
+    display: unset;
+  }
 
-    .block.magazine-articles .articles article {
-        display: inline-flex;
-    }
+  .block.magazine-articles .articles article {
+    display: inline-flex;
+  }
 
-    .block.magazine-articles article a.imgcover {
-        padding-right: 15px;
-        height: auto;
-    }
+  .block.magazine-articles article a.imgcover {
+    padding-right: 15px;
+    height: auto;
+  }
 
-    .section.magazine-articles-container > div > div > div.articles > article > a > picture {
-        float: left;
-        height: 214px;
-        width: 380px;    
-    }
+  .section.magazine-articles-container > div > div > div.articles > article > a > picture {
+    float: left;
+    height: 214px;
+    width: 380px;
+  }
 
-    .block.magazine-articles .article-list article {
-        display: inline-flex;
-        width: 100%;
-    }
+  .block.magazine-articles .article-list article {
+    display: inline-flex;
+    width: 100%;
+  }
 
-    .block.magazine-articles .article-list article .content {
-        padding-left: 15px;
-    }
+  .block.magazine-articles article picture.default-image img {
+    object-fit: cover;
+  }
 
-    /* make sure the fields have the same width when stacked */
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(odd) { min-width: 396px; }
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(even) { min-width: 341px; }
+  .block.magazine-articles .article-list article .content {
+    padding-left: 15px;
+  }
+
+  /* make sure the fields have the same width when stacked */
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(odd) {
+    min-width: 396px;
+  }
+
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
+    min-width: 341px;
+  }
 }
 
 @media screen and (min-width: 1300px) {
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(odd),
-    .block.magazine-articles .list-filter fieldset div:nth-of-type(even) { min-width: unset; }   
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(odd),
+  .block.magazine-articles .list-filter fieldset div:nth-of-type(even) {
+    min-width: unset;
+  }
 }

--- a/blocks/magazine-articles/magazine-articles.js
+++ b/blocks/magazine-articles/magazine-articles.js
@@ -27,6 +27,7 @@ function buildMagazineArticle(entry) {
     category,
     readingTime,
     publishDate,
+    isDefaultImage,
   } = entry;
   const card = createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '380', height: '214' }]);
@@ -46,6 +47,7 @@ function buildMagazineArticle(entry) {
     <li>${readingTime}</li>
     </ul>
     </div>`;
+  card.querySelector('picture').classList.toggle('default-image', isDefaultImage);
   return card;
 }
 
@@ -190,17 +192,23 @@ async function getMagazineArticles({
       return tempData;
     }
 
+    const isImageLink = (link) => link.match(/\.(jpeg|jpg|gif|png|svg|bmp|webp)$/) !== null;
+
+    const getDefaultImage = () => {
+      const logoImageURL = '/media/logo/media_10a115d2f3d50f3a22ecd2075307b4f4dcaedb366.jpeg';
+      return getOrigin() + logoImageURL;
+    };
+
     const { items, count } = rawData.data.volvosearch;
     tempData.push(...items.map((item) => ({
       ...item.metadata,
       filterTag: item.metadata.tags,
       author: item.metadata.articleAuthor || defaultAuthor,
-      // to avoid to show a broken image, shows the og:image from the page's metadata
-      // As soon we have a default image for articles, we can update this condition to show it
-      image: item.metadata.articleImage.endsWith('/')
-        ? getMetadata('og:image') : getOrigin() + item.metadata.articleImage,
+      image: isImageLink(item.metadata.articleImage)
+        ? getOrigin() + item.metadata.articleImage : getDefaultImage(),
       path: item.uuid,
       readingTime: /\d+/.test(item.metadata.readTime) ? item.metadata.readTime : defaultReadTime,
+      isDefaultImage: !isImageLink(item.metadata.articleImage),
     })));
 
     if (!hasLimit && tempData.length < count) {

--- a/blocks/magazine-articles/magazine-articles.js
+++ b/blocks/magazine-articles/magazine-articles.js
@@ -1,6 +1,8 @@
 import {
   getLanguagePath,
   getOrigin,
+  getTextLabel,
+  createElement,
 } from '../../scripts/common.js';
 import {
   ffetch,
@@ -14,6 +16,7 @@ import {
   getMetadata,
   toClassName,
 } from '../../scripts/aem.js';
+import { fetchData, magazineSearchQuery } from '../../scripts/search-api.js';
 
 const locale = getMetadata('locale');
 
@@ -28,11 +31,11 @@ function buildMagazineArticle(entry) {
     readingTime,
     publishDate,
   } = entry;
-  const card = document.createElement('article');
+  const card = createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '380', height: '214' }]);
   const pictureTag = picture.outerHTML;
   const date = new Date((publishDate * 1000) + (new Date().getTimezoneOffset() * 60000));
-  const categoryItem = document.createElement('li');
+  const categoryItem = createElement('li');
   card.innerHTML = `<a href="${path}" class="imgcover">
     ${pictureTag}
     </a>
@@ -57,7 +60,7 @@ function buildLatestMagazineArticle(entry) {
     description,
     linkText,
   } = entry;
-  const card = document.createElement('article');
+  const card = createElement('article');
   const picture = createOptimizedPicture(image, title, false, [{ width: '590', height: '410' }]);
   const pictureTag = picture.outerHTML;
   const readMore = (linkText || 'Read more...');
@@ -87,7 +90,34 @@ async function getFilterOptions() {
   return { categoryList, topicList, truckSeriesList };
 }
 
+//#region Filter Articles
 function filterArticles(articles, activeFilters) {
+  const { category, topic, truck, search } = activeFilters;
+  console.log('filtered articles no JSON', { category, topic, truck, search, articles });
+  if (category || topic || truck) {
+    // do a query again with any of these filters
+    const tags = [];
+    if (category) {
+      tags.push(category);
+    }
+    if (topic) {
+      tags.push(topic);
+    }
+    if (truck) {
+      tags.push(truck);
+    }
+
+    // eslint-disable-next-line no-use-before-define
+    Promise.resolve(getMagazineArticles({ tags })).then((data) => {
+      console.log('%cfiltered articles no JSON', 'color:lightgreen', { data });
+      return data;
+    });
+  }
+  return articles;
+}
+// #endregion
+
+function filterArticlesJSON(articles, activeFilters) {
   let filteredArticles = articles;
 
   filteredArticles = filteredArticles.filter((n) => {
@@ -109,10 +139,11 @@ function filterArticles(articles, activeFilters) {
   return filteredArticles;
 }
 
-async function createFilter(articles, activeFilters, createDropdown, createFullText) {
+async function createFilter(articles, activeFilters, createDropdown, createInputSearch) {
+  const searchText = getTextLabel('Search');
   const [tagList, search] = await Promise.all([
     getFilterOptions(),
-    createFullText('search', activeFilters.search, 'Search'),
+    createInputSearch(searchText.toLowerCase(), activeFilters.search, searchText),
   ]);
 
   const categoryFilter = createDropdown(tagList.categoryList, activeFilters.category, 'category', 'All Categories');
@@ -136,11 +167,16 @@ async function createFilter(articles, activeFilters, createDropdown, createFullT
 }
 
 function createArticleList(block, articles, limit) {
+  console.log('%ccreateArticleList', 'color:deeppink', { block, articles, limit });
+  createList(articles, filterArticles, createFilter, buildMagazineArticle, limit, block);
+}
+
+function createArticleListJSON(block, articles, limit) {
   articles.forEach((n) => {
     n.filterTag = splitTags(n.tags);
   });
   // eslint-disable-next-line max-len
-  createList(articles, filterArticles, createFilter, buildMagazineArticle, limit, block);
+  createList(articles, filterArticlesJSON, createFilter, buildMagazineArticle, limit, block);
 }
 
 async function createLatestMagazineArticles(mainEl, magazineArticles) {
@@ -154,7 +190,74 @@ async function createLatestMagazineArticles(mainEl, magazineArticles) {
   });
 }
 
-async function getMagazineArticles(limit) {
+const tempData = [];
+
+async function getMagazineArticles({
+  limit, offset = 0, tags = null, q = 'truck',
+} = {}) {
+  const hasLimit = limit !== undefined;
+  const variables = {
+    tenant: 'franklin-vg-volvotrucks-us',
+    language: 'EN',
+    q,
+    facets: [
+      {
+        field: 'TAGS',
+      },
+    ],
+    filters: [{ field: 'CATEGORY', value: 'magazine' }],
+    limit: hasLimit ? limit : null,
+    offset,
+  };
+
+  if (tags && tags.length) {
+    tags.forEach((tag) => {
+      variables.filters.push({ field: 'TAGS', value: tag });
+    });
+  }
+
+  const rawData = await fetchData({
+    query: magazineSearchQuery(),
+    variables,
+  });
+
+  const querySuccess = rawData && rawData.data && rawData.data.volvosearch;
+
+  if (!querySuccess) {
+    return tempData;
+  }
+
+  const { items, count } = rawData.data.volvosearch;
+  // #region Test Data
+  if (items.length > 0) {
+    items[0].metadata.readTime = '12 min'; 
+    items[0].metadata.articleAuthor = 'Jonatan Lledo'; 
+    items[0].metadata.articleImage = '/news-and-stories/volvo-trucks-magazine/preserving-a-deep-history/media_1ddd9858e76322a897b672e9cfafc0bb1537be3a6.jpeg?width=1200&format=pjpg&optimize=medium'; 
+  }
+  // #endregion
+  tempData.push(...items.map((item) => ({
+    ...item.metadata,
+    filterTag: item.metadata.tags,
+    author: item.metadata.articleAuthor || getTextLabel('Volvo Trucks NA'),
+    // to avoid to show a broken image, shows the og:image from the page's metadata
+    // As soon we have a default image for articles, we can update this condition to show it
+    image: item.metadata.articleImage.endsWith('/')
+      ? getMetadata('og:image') : getOrigin() + item.metadata.articleImage,
+    path: item.uuid,
+    readingTime: /\d+/.test(item.metadata.readTime) ? item.metadata.readTime : getTextLabel('11 min'),
+    description: getTextLabel('Volvo Trucks NA'),
+  })));
+
+  if (!hasLimit && tempData.length < count) {
+    return getMagazineArticles({ limit: count, offset: tempData.length });
+  }
+  const sortedByDate = [...tempData.sort((a, b) => b.publishDate - a.publishDate)];
+  tempData.length = 0;
+  console.log('%cgetMagazineArticles', 'color:cyan', { sortedByDate });
+  return sortedByDate;
+}
+
+async function getMagazineArticlesJSON(limit) {
   const indexUrl = new URL(`${getLanguagePath()}magazine-articles.json`, getOrigin());
   let articles;
   if (limit) {
@@ -166,13 +269,23 @@ async function getMagazineArticles(limit) {
 }
 
 export default async function decorate(block) {
+  // #region Latest test
+  // if (!block.classList.contains('latest')) {
+  //   console.log('Not latest');
+  //   block.classList.add('latest');
+  // }
+  // #endregion
   const latest = block.classList.contains('latest');
   const limit = latest ? 3 : undefined;
   const limitPerPage = 8;
-  const magazineArticles = await getMagazineArticles(limit);
+  const magazineArticles = await getMagazineArticles({ limit });
+  const magazineArticlesJSON = await getMagazineArticlesJSON(limit);
+  console.log('%cmagazineArticles', 'color:gold', { magazineArticles, magazineArticlesJSON });
   if (latest) {
-    createLatestMagazineArticles(block, magazineArticles);
+    createLatestMagazineArticles(block, magazineArticlesJSON);
+    // createLatestMagazineArticles(block, magazineArticles);
   } else {
+    // createArticleListJSON(block, magazineArticlesJSON, limitPerPage);
     createArticleList(block, magazineArticles, limitPerPage);
   }
 }

--- a/blocks/search/autosuggest.js
+++ b/blocks/search/autosuggest.js
@@ -1,5 +1,5 @@
 import { createElement } from '../../scripts/common.js';
-import { autosuggestQuery, fetchData } from './search-api.js';
+import { autosuggestQuery, fetchData } from '../../scripts/search-api.js';
 
 const autoSuggestClass = 'autosuggest-results-item-highlighted';
 const tenant = 'franklin-vg-volvotrucks-us';

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -68,6 +68,16 @@ export default function decorate(block) {
   const sortBy = document.getElementById('searchOptionsSection');
   const listEl = block.querySelector('.autosuggest__results-container ul');
 
+  function sanitizeQueryTerm(query) {
+    return query.replace(/[<>]/g, (tag) => {
+      const replacements = {
+        '<': '&lt;',
+        '>': '&gt;',
+      };
+      return replacements[tag] || tag;
+    });
+  }
+
   function searchResults(hideAutoSuggest = true) {
     if (hideAutoSuggest) {
       listEl.textContent = '';
@@ -83,7 +93,7 @@ export default function decorate(block) {
 
   searchBtn.onclick = () => searchResults();
 
-  const onclickHanlder = (val) => {
+  const onclickHandler = (val) => {
     input.value = val;
     searchResults();
   };
@@ -95,7 +105,7 @@ export default function decorate(block) {
       role: 'option',
       'data-section-name': 'default',
     },
-  }, onclickHanlder));
+  }, onclickHandler));
 
   let liSelected;
   let next;
@@ -277,7 +287,7 @@ export default function decorate(block) {
 
   function showResults(data) {
     const { items, count, facets } = data;
-    const queryTerm = input.value; // TODO: it needs to be sanitized first to avoid XSS
+    const queryTerm = sanitizeQueryTerm(input.value);
     let resultsText = '';
     let facetsText = null;
     if (items.length > 0) { // items by query: 25, count has the total
@@ -351,7 +361,7 @@ export default function decorate(block) {
 
   async function fetchResults() {
     const searchParams = new URLSearchParams(window.location.search);
-    const queryTerm = searchParams.get(_q); // TODO: it needs to be sanitized first to avoid XSS
+    const queryTerm = sanitizeQueryTerm(searchParams.get(_q));
     const offsetVal = Number(searchParams.get(_start));
     const sortVal = searchParams.get(_sort) || 'BEST_MATCH';
 

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -8,7 +8,7 @@ import {
   getShowingResultsTemplate,
 } from './templates.js';
 
-import { searchQuery, fetchData } from './search-api.js';
+import { searchQuery, fetchData } from '../../scripts/search-api.js';
 
 import { fetchAutosuggest, handleArrowDown, handleArrowUp } from './autosuggest.js';
 
@@ -277,7 +277,7 @@ export default function decorate(block) {
 
   function showResults(data) {
     const { items, count, facets } = data;
-    const queryTerm = input.value;
+    const queryTerm = input.value; // TODO: it needs to be sanitized first to avoid XSS
     let resultsText = '';
     let facetsText = null;
     if (items.length > 0) { // items by query: 25, count has the total
@@ -351,7 +351,7 @@ export default function decorate(block) {
 
   async function fetchResults() {
     const searchParams = new URLSearchParams(window.location.search);
-    const queryTerm = searchParams.get(_q);
+    const queryTerm = searchParams.get(_q); // TODO: it needs to be sanitized first to avoid XSS
     const offsetVal = Number(searchParams.get(_start));
     const sortVal = searchParams.get(_sort) || 'BEST_MATCH';
 

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -83,7 +83,7 @@ export default function decorate(block) {
 
   searchBtn.onclick = () => searchResults();
 
-  const onclickHandler = (val) => {
+  const onClickHandler = (val) => {
     input.value = val;
     searchResults();
   };
@@ -95,7 +95,7 @@ export default function decorate(block) {
       role: 'option',
       'data-section-name': 'default',
     },
-  }, onclickHandler));
+  }, onClickHandler));
 
   let liSelected;
   let next;

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -8,7 +8,7 @@ import {
   getShowingResultsTemplate,
 } from './templates.js';
 
-import { searchQuery, fetchData } from '../../scripts/search-api.js';
+import { searchQuery, fetchData, sanitizeQueryTerm } from '../../scripts/search-api.js';
 
 import { fetchAutosuggest, handleArrowDown, handleArrowUp } from './autosuggest.js';
 
@@ -67,16 +67,6 @@ export default function decorate(block) {
   const summary = document.getElementById('searchResultSummarySection');
   const sortBy = document.getElementById('searchOptionsSection');
   const listEl = block.querySelector('.autosuggest__results-container ul');
-
-  function sanitizeQueryTerm(query) {
-    return query.replace(/[<>]/g, (tag) => {
-      const replacements = {
-        '<': '&lt;',
-        '>': '&gt;',
-      };
-      return replacements[tag] || tag;
-    });
-  }
 
   function searchResults(hideAutoSuggest = true) {
     if (hideAutoSuggest) {

--- a/blocks/vin-number/vin-number.js
+++ b/blocks/vin-number/vin-number.js
@@ -152,7 +152,7 @@ function renderRecalls(recallsData) {
 function getAPIConfig() {
   let env = 'prod';
 
-  if (window.location.host.includes('hlx.page')) {
+  if (['hlx.page', 'aem.page'].some((host) => window.location.host.includes(host))) {
     env = 'qa';
   } else if (window.location.host.includes('localhost')) {
     env = 'dev';

--- a/placeholder.json
+++ b/placeholder.json
@@ -326,6 +326,14 @@
     {
       "Key": "readMoreBtn",
       "Text": "Read More"
+    },
+    {
+      "Key": "defaultAuthor",
+      "Text": "Volvo Trucks NA"
+    },
+    {
+      "Key": "defaultReadTime",
+      "Text": "10 min"
     }
   ],
   ":type": "sheet"

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -563,3 +563,8 @@ export const deepMerge = (target, source) => {
   });
   return target;
 };
+
+export const isDevHost = () => {
+  const devHosts = ['localhost', 'hlx.page', 'hlx.live', 'aem.page', 'aem.live'];
+  return devHosts.some((url) => window.location.host.includes(url));
+};

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -4,11 +4,10 @@ import {
   isPerformanceAllowed,
   isTargetingAllowed,
   isSocialAllowed,
+  isDevHost,
   extractObjectFromArray,
   COOKIE_CONFIGS,
 } from './common.js';
-
-const devHosts = ['localhost', 'hlx.page', 'hlx.live', 'aem.page', 'aem.live'];
 
 // COOKIE ACCEPTANCE AND IDs default to false in case no ID is present
 const { 
@@ -56,7 +55,7 @@ document.addEventListener('click', (e) => {
 
 // OneTrust Cookies Consent Notice start for volvotrucks.us
 if (!window.location.pathname.includes('srcdoc')
-  && !devHosts.some((url) => window.location.host.includes(url))) {
+  && !isDevHost()) {
   // when running on localhost in the block library host is empty but the path is srcdoc
   // on localhost/hlx.page/hlx.live the consent notice is displayed every time the page opens,
   // because the cookie is not persistent. To avoid this annoyance, disable unless on the
@@ -89,7 +88,7 @@ if (!window.location.pathname.includes('srcdoc')
   };
 }
 
-if (devHosts.some((url) => window.location.host.includes(url))) {
+if (isDevHost()) {
   import('./validate-elements.js');
 }
 

--- a/scripts/magazine-press.js
+++ b/scripts/magazine-press.js
@@ -3,6 +3,7 @@ import {
   readBlockConfig,
   toClassName,
 } from './aem.js';
+import { createElement } from './common.js';
 
 /*
 * Common functions for searching the press releases and magazines
@@ -13,18 +14,22 @@ function getSelectionFromUrl(field) {
   );
 }
 
-function createFullText(name, searchTerm, placeholder) {
-  const container = document.createElement('div');
-  container.className = toClassName(`${name}-field`);
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.name = name;
-  if (!searchTerm) {
-    input.placeholder = placeholder;
-  } else {
+function createInputSearch(name, searchTerm, placeholder) {
+  const container = createElement('div', {
+    classes: toClassName(`${name}-field`),
+  });
+  const input = createElement('input', {
+    props: {
+      type: 'text',
+      name,
+      placeholder,
+    },
+  });
+
+  if (searchTerm) {
     input.value = searchTerm;
   }
-  const btn = document.createElement('button');
+  const btn = createElement('button');
   btn.innerHTML = `
     <i class="fa fa-search"></i>
   `;
@@ -33,21 +38,25 @@ function createFullText(name, searchTerm, placeholder) {
 }
 
 function createDropdown(options, selected, name, placeholder, label) {
-  const container = document.createElement('div');
-  container.className = toClassName(`${name}-field`);
+  const container = createElement('div', {
+    classes: toClassName(`${name}-field`),
+  });
   if (label) {
-    const labelEl = document.createElement('label');
+    const labelEl = createElement('label', {
+      props: { for: name },
+    });
     labelEl.innerText = label;
-    labelEl.setAttribute('for', name);
     container.append(labelEl);
   }
-  const input = document.createElement('select');
-  input.name = name;
-  input.id = name;
+  const input = createElement('select', {
+    props: {
+      name,
+      id: name,
+    },
+  });
   if (placeholder) {
-    const optionTag = document.createElement('option');
+    const optionTag = createElement('option', { props: { value: '' } });
     optionTag.innerText = placeholder;
-    optionTag.value = '';
     if (!selected) {
       optionTag.selected = true;
     }
@@ -55,9 +64,10 @@ function createDropdown(options, selected, name, placeholder, label) {
   }
 
   options.forEach((option) => {
-    const optionTag = document.createElement('option');
+    const optionTag = createElement('option', {
+      props: { value: toClassName(option) },
+    });
     optionTag.innerText = option;
-    optionTag.value = toClassName(option);
     if (optionTag.value === selected) {
       optionTag.selected = true;
     }
@@ -69,36 +79,29 @@ function createDropdown(options, selected, name, placeholder, label) {
 
 function createPaginationLink(page, label) {
   const newUrl = new URL(window.location);
-  const listElement = document.createElement('li');
-  const link = document.createElement('a');
+  const listElement = createElement('li');
+  const link = createElement('a', { classes: label });
   newUrl.searchParams.set('page', page);
   link.href = newUrl.toString();
-  link.className = label;
   listElement.append(link);
   return listElement;
 }
 
 function createPagination(entries, page, limit) {
-  const listPagination = document.createElement('div');
-  listPagination.className = 'pager';
-
-  const totalResults = document.createElement('div');
-  totalResults.className = 'total';
+  const listPagination = createElement('div', { classes: 'pager' });
+  const totalResults = createElement('div', { classes: 'total' });
   totalResults.textContent = `${entries.length} results`;
   listPagination.appendChild(totalResults);
-  const pagination = document.createElement('div');
-  pagination.className = 'pagination';
+  const pagination = createElement('div', { classes: 'pagination' });
 
   if (entries.length > limit) {
     const maxPages = Math.ceil(entries.length / limit);
 
-    const listSize = document.createElement('span');
-    listSize.classList.add('size');
+    const listSize = createElement('span', { classes: 'size' });
     if (entries.length > limit) {
       listSize.innerHTML = `<strong>Page ${page}</strong> of ${maxPages}`;
     }
-    const list = document.createElement('ol');
-    list.className = 'scroll';
+    const list = createElement('ol', { classes: 'scroll' });
     if (page === 1) {
       list.append(createPaginationLink(page + 1, 'next'));
       list.append(createPaginationLink(maxPages, 'last'));
@@ -119,10 +122,7 @@ function createPagination(entries, page, limit) {
 }
 
 export function splitTags(tags) {
-  if (tags) {
-    return JSON.parse(tags);
-  }
-  return [];
+  return tags ? JSON.parse(tags) : [];
 }
 
 function getActiveFilters() {
@@ -138,14 +138,11 @@ function getActiveFilters() {
 
 async function renderFilters(data, createFilters) {
   // render filters
-  const filter = document.createElement('div');
-  filter.className = 'list-filter';
-  const form = document.createElement('form');
-  form.method = 'get';
-  form.name = 'list-filter';
-  const formFieldSet = document.createElement('fieldset');
+  const filter = createElement('div', { classes: 'list-filter' });
+  const form = createElement('form', { props: { method: 'get', name: 'list-filter' } });
+  const formFieldSet = createElement('fieldset');
 
-  const filters = await createFilters(data, getActiveFilters(), createDropdown, createFullText);
+  const filters = await createFilters(data, getActiveFilters(), createDropdown, createInputSearch);
   formFieldSet.append(
     ...filters,
   );
@@ -186,10 +183,9 @@ async function buildElements(pressReleases, filter, createFilters, buildPressRel
     const start = (page - 1) * limitPerPage;
     filteredData = filteredData.slice(start, start + limitPerPage);
   }
-  const articleList = document.createElement('ul');
-  articleList.className = 'article-list';
+  const articleList = createElement('ul', { classes: 'article-list' });
   filteredData.forEach((pressRelease) => {
-    const articleItem = document.createElement('li');
+    const articleItem = createElement('li');
     const pressReleaseArticle = buildPressReleaseArticle(pressRelease);
     articleItem.appendChild(pressReleaseArticle);
     articleList.appendChild(articleItem);
@@ -222,7 +218,7 @@ export async function createList(pressReleases, filter, createFilters, buildPres
     reloadList(new URL(event.target.href).searchParams);
   }
 
-  function attachSubmitListners(filter) {
+  function attachSubmitListeners(filter) {
     const form = filter.querySelector('form');
     if (form) {
       form.submit = reloadFilteredList.bind(form);
@@ -231,17 +227,17 @@ export async function createList(pressReleases, filter, createFilters, buildPres
     return filter;
   }
 
-  function attachClickListners(pagination) {
+  function attachClickListeners(pagination) {
     pagination.querySelectorAll('a').forEach((a) => a.addEventListener('click', reloadPaginatedList));
     return pagination;
   }
 
   function renderList(el, { filter, pagination, list }) {
     const children = [];
-    if (filter) children.push(attachSubmitListners(filter));
-    if (pagination) children.push(attachClickListners(pagination));
+    if (filter) children.push(attachSubmitListeners(filter));
+    if (pagination) children.push(attachClickListeners(pagination));
     children.push(list);
-    if (pagination) children.push(attachClickListners(pagination.cloneNode(true)));
+    if (pagination) children.push(attachClickListeners(pagination.cloneNode(true)));
     el.replaceChildren(...children);
   }
 

--- a/scripts/magazine-press.js
+++ b/scripts/magazine-press.js
@@ -210,7 +210,13 @@ export async function createList(pressReleases, filter, createFilters, buildPres
 
   function reloadFilteredList(event) {
     if (event) event.preventDefault();
-    reloadList(new URLSearchParams(new FormData(this)));
+    const params = new URLSearchParams(new FormData(this));
+    const urlParams = new URL(window.location).searchParams;
+    const page = urlParams.get('page');
+    if (page && +page > 1) {
+      params.set('page', 1);
+    }
+    reloadList(params);
   }
 
   function reloadPaginatedList(event) {

--- a/scripts/magazine-press.js
+++ b/scripts/magazine-press.js
@@ -165,7 +165,7 @@ async function buildElements(pressReleases, filter, createFilters, buildPressRel
     };
     relatedPressReleases = true;
   }
-  let filteredData = filter ? filter(pressReleases, actFilter) : pressReleases;
+  let filteredData = filter ? await filter(pressReleases, actFilter) : pressReleases;
 
   let page = parseInt(getSelectionFromUrl('page'), 10);
   page = Number.isNaN(page) ? 1 : page;

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -1,24 +1,30 @@
-import { SEARCH_URLS } from '../../scripts/common.js';
+import { SEARCH_URLS, isDevHost } from './common.js';
 
 const { SEARCH_URL_DEV, SEARCH_URL_PROD } = SEARCH_URLS;
-const isProd = !window.location.host.includes('hlx.page') && !window.location.host.includes('localhost');
+const isProd = !isDevHost();
 const SEARCH_LINK = !isProd ? SEARCH_URL_DEV : SEARCH_URL_PROD;
 
 export async function fetchData(queryObj) {
-  const response = await fetch(
-    SEARCH_LINK,
-    {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'Content-Length': queryObj.length,
+  try {
+    const response = await fetch(
+      SEARCH_LINK,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Content-Length': queryObj.length,
+        },
+        body: JSON.stringify(queryObj),
       },
-      body: JSON.stringify(queryObj),
-    },
-  );
+    );
 
-  return response.json();
+    return response.json();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching data:', error);
+    throw error;
+  }
 }
 
 export const searchQuery = (hasFilters) => `
@@ -54,3 +60,25 @@ query Volvosuggest($term: String!, $tenant: String!, $locale: VolvoLocaleEnum!, 
     terms
   }
 }`;
+
+export const recommendQuery = () => `
+query Volvorecommend($tenant: String!, $language: VolvoLocaleEnum!, $category: String) {
+  volvorecommend(tenant: $tenant, language: $language, category: $category) {
+    items {
+      uuid
+      metadata {
+        url
+        title
+        description
+        lastModified
+      }
+      score
+    }
+    facets {
+      value
+      count
+    }
+    count
+  }
+}
+`;

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -71,24 +71,42 @@ query Volvosuggest($term: String!, $tenant: String!, $locale: VolvoLocaleEnum!, 
   }
 }`;
 
-export const recommendQuery = () => `
-query Volvorecommend($tenant: String!, $language: VolvoLocaleEnum!, $category: String) {
-  volvorecommend(tenant: $tenant, language: $language, category: $category) {
+export const magazineSearchQuery = () => `
+query Volvosearch($tenant: String!, $language: VolvoLocaleEnum!, $q: String, $facets: [VolvoFacet], $filters: [VolvoFilterItem], $limit: Int, $offset: Int) {
+  volvosearch(tenant: $tenant, language: $language, q: $q, facets: $facets, filters: $filters, limit: $limit, offset: $offset) {
+    count
+    facets {
+      field
+      items {
+        value
+        count
+      }
+    }
     items {
       uuid
       metadata {
-        url
         title
         description
+        url
         lastModified
+        language
+        articleAuthor {
+          name
+          profileImage
+        }
+        locale
+        readTime
+        location
+        media
+        contentPath
+        resourceType
+        displayDate
+        tags
+        publishDate
+        articleImage
       }
       score
     }
-    facets {
-      value
-      count
-    }
-    count
   }
 }
 `;

--- a/scripts/search-api.js
+++ b/scripts/search-api.js
@@ -27,6 +27,16 @@ export async function fetchData(queryObj) {
   }
 }
 
+export function sanitizeQueryTerm(query) {
+  return query.replace(/[<>]/g, (tag) => {
+    const replacements = {
+      '<': '&lt;',
+      '>': '&gt;',
+    };
+    return replacements[tag] || tag;
+  });
+}
+
 export const searchQuery = (hasFilters) => `
 query Volvosearch($tenant: String!, $q: String, $offset: Int, $limit: Int, $language: VolvoLocaleEnum!,
 $facets: [VolvoFacet], $sort: [VolvoSortOptionsEnum]${hasFilters ? ', $filters: [VolvoFilterItem]' : ''}) {


### PR DESCRIPTION
# Update

Use search API to update the article's list so every change in the filter is a new API call, not only once at the beginning

## Also Fix

- Fix an issue related to general Search #720
- Fix a pagination bug 

### Pagination bug
That occurs after changing the pagination to a page number greater than the amount of the next results needed it doesn't show any item if the results don't bring results. Now, when the user does a new filtering, it updates the page again to page 1

To test the bug, go to a pagination page, like page 3 or more, and change the filters to another value, e.g. filter by another truck. It should go to pagination 1 including the URL parameter

#

Fix #688, #720

## Test URLs:
### without any filter
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/
- After: https://688-search-using-endpoint--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/

### with filters
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/?search=further&category=product&topic=volvo-trucks-magazine&truck=vnl&page=1
- After: https://688-search-using-endpoint--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/?search=further&category=product&topic=volvo-trucks-magazine&truck=vnl&page=1

### pagination bug
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/?page=7
- After: https://688-search-using-endpoint--vg-volvotrucks-us--hlxsites.aem.page/news-and-stories/volvo-trucks-magazine/?page=7

### 720 related link
- After: https://688-search-using-endpoint--vg-volvotrucks-us--hlxsites.aem.page/search-results?q=%3Cimg%20src=%22https://imgflip.com/s/meme/Scared-Cat.jpg%22%20onload=alert(%22xss%22)%3E&start=0