### PR TITLE
Multi language sites constants file location #733

### DIFF
--- a/head.html
+++ b/head.html
@@ -6,21 +6,20 @@
 <script type="module">
   import { getLanguagePath } from '/scripts/common.js';
 
-  let dynamicUrl;
   try {
-    dynamicUrl = `${getLanguagePath()}constants.json`;
+    const dynamicUrl = `${getLanguagePath()}constants.json`;
+
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.href = dynamicUrl;
+    link.as = 'fetch';
+    link.type = 'application/json';
+    link.crossorigin = 'anonymous';
+
+    document.head.appendChild(link);
   } catch (error) {
     console.log(error);
   }
-
-  const link = document.createElement('link');
-  link.rel = 'preload';
-  link.href = dynamicUrl;
-  link.as = 'fetch';
-  link.type = 'application/json';
-  link.crossorigin = 'anonymous';
-
-  document.head.appendChild(link);
 </script>
 <link rel="stylesheet" href="/styles/styles.css" />
 <link rel="icon" href="data:," />

--- a/head.html
+++ b/head.html
@@ -1,21 +1,26 @@
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="referrer" content="no-referrer-when-downgrade" />
-<link rel="modulepreload" href="/scripts/scripts.js"/>
+<link rel="modulepreload" href="/scripts/scripts.js" />
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
 <script type="module">
-    import { getLanguagePath } from '/scripts/common.js';
-  
-    const dynamicUrl = `${getLanguagePath()}constants.json`;
-  
-    const link = document.createElement('link');
-    link.rel = 'preload';
-    link.href = dynamicUrl;
-    link.as = 'fetch';
-    link.type = 'application/json';
-    link.crossorigin = 'anonymous';
-  
-    document.head.appendChild(link);
-  </script>
-<link rel="stylesheet" href="/styles/styles.css"/>
-<link rel="icon" href="data:,">
+  import { getLanguagePath } from '/scripts/common.js';
+
+  let dynamicUrl;
+  try {
+    dynamicUrl = `${getLanguagePath()}constants.json`;
+  } catch (error) {
+    console.log(error);
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.href = dynamicUrl;
+  link.as = 'fetch';
+  link.type = 'application/json';
+  link.crossorigin = 'anonymous';
+
+  document.head.appendChild(link);
+</script>
+<link rel="stylesheet" href="/styles/styles.css" />
+<link rel="icon" href="data:," />

--- a/head.html
+++ b/head.html
@@ -3,6 +3,19 @@
 <link rel="modulepreload" href="/scripts/scripts.js"/>
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<link rel="preload" href="/constants.json" as="fetch" type="application/json" crossorigin="anonymous"/>
+<script type="module">
+    import { getLanguagePath } from '/scripts/common.js';
+  
+    const dynamicUrl = `${getLanguagePath()}constants.json`;
+  
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.href = dynamicUrl;
+    link.as = 'fetch';
+    link.type = 'application/json';
+    link.crossorigin = 'anonymous';
+  
+    document.head.appendChild(link);
+  </script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -398,8 +398,11 @@ export const slugify = (text) => (
     .replace(/--+/g, '-')
 );
 
+/**
+ * loads the constants file where configuration values are stored
+ */
 async function getConstantValues() {
-  const url = '/constants.json';
+  const url = `${getLanguagePath()}constants.json`;
   let constants;
   try {
     const response = await fetch(url).then((resp) => resp.json());


### PR DESCRIPTION
Fix #733

Note:
In order to check this functionality in **actual multi-language sites**, I created the branch `TESTING` in the Canada Repository.
For each language the site should retrieve one or the other `constants.xlsx` file

Link here: 
https://testing--vg-volvotrucks-ca--hlxsites.hlx.page/en-ca/ --> or /fr-ca/ 


Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/
- After: https://733-multi-lang-config--vg-volvotrucks-us--hlxsites.aem.page/
