### PR TITLE
FR: [V2 Stories Carousel] Variant - Related Articles #541

### DIFF
--- a/blocks/v2-stories-carousel/v2-stories-carousel.css
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.css
@@ -10,6 +10,7 @@ body .section.v2-stories-carousel-container .v2-stories-carousel-wrapper {
   padding-left: 0;
   padding-right: 0;
   width: 100%;
+  max-width: none;
 }
 
 /* End Full width block */

--- a/blocks/v2-stories-carousel/v2-stories-carousel.js
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.js
@@ -13,6 +13,9 @@ import { smoothScrollHorizontal } from '../../scripts/motion-helper.js';
 
 const blockName = 'v2-stories-carousel';
 const locale = getMetadata('locale');
+const lowLimit = 3;
+const highLimitDefault = 5;
+const highLimitRelatedArticles = 7;
 
 const updateActiveClass = (elements, targetElement) => {
   elements.forEach((el) => {
@@ -194,9 +197,9 @@ const createStoriesCarousel = (block, stories) => {
 
 export default async function decorate(block) {
   const isRelatedArticles = block.classList.contains('related-articles');
-  let limit = isRelatedArticles ? 7 : 5;
+  let limit = isRelatedArticles ? highLimitRelatedArticles : highLimitDefault;
   limit = parseFloat(block.textContent.trim()) || limit;
-  if (limit < 3) limit = 3;
+  limit = Math.max(limit, lowLimit);
 
   block.innerHTML = '';
   let stories;

--- a/blocks/v2-stories-carousel/v2-stories-carousel.js
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.js
@@ -14,8 +14,7 @@ import { smoothScrollHorizontal } from '../../scripts/motion-helper.js';
 const blockName = 'v2-stories-carousel';
 const locale = getMetadata('locale');
 const lowLimit = 3;
-const highLimitDefault = 5;
-const highLimitRelatedArticles = 7;
+const highLimit = 7;
 
 const updateActiveClass = (elements, targetElement) => {
   elements.forEach((el) => {
@@ -197,8 +196,7 @@ const createStoriesCarousel = (block, stories) => {
 
 export default async function decorate(block) {
   const isRelatedArticles = block.classList.contains('related-articles');
-  let limit = isRelatedArticles ? highLimitRelatedArticles : highLimitDefault;
-  limit = parseFloat(block.textContent.trim()) || limit;
+  let limit = parseFloat(block.textContent.trim()) || highLimit;
   limit = Math.max(limit, lowLimit);
 
   block.innerHTML = '';


### PR DESCRIPTION
Fix #541

Test URLs:
- Before: https://main--vg-volvotrucks-us--hlxsites.aem.page/
- After: https://541-stories-carusel-variant--vg-volvotrucks-us--hlxsites.aem.page/

The related-articles variant for stories carousel was added to https://541-stories-carusel-variant--vg-volvotrucks-us--hlxsites.aem.page/drafts/luka/driving-the-future/ where it appears above newsletter subscription. 

It looks the same as the original stories one, but it filters article selection by tags. If the limit is 7, it will first show 7 articles matching the first tag of the currently open article. If there are less such articles than the limit, articles with second tag will be added and so on.
