### PR TITLE
Remove all caps from article cards block #702

### DIFF
--- a/blocks/v2-article-cards/v2-article-cards.css
+++ b/blocks/v2-article-cards/v2-article-cards.css
@@ -65,6 +65,7 @@
 }
 
 .v2-article-cards__texts-wrapper .v2-article-cards__card-heading {
+  text-transform: unset;
   color: var(--text-color);
   font-size: var(--f-heading-5-font-size);
 }


### PR DESCRIPTION
Fix #702 

-Before: https://main--vg-volvotrucks-us--hlxsites.hlx.page/drafts/shomps/v2-article-cards
-After: https://702-remove-all-caps--vg-volvotrucks-us--hlxsites.hlx.page/drafts/shomps/v2-article-cards
