### PR TITLE
Hotfix carousel arrows misalignment 761

### DIFF
--- a/blocks/v2-stories-carousel/v2-stories-carousel.css
+++ b/blocks/v2-stories-carousel/v2-stories-carousel.css
@@ -148,58 +148,6 @@ ul.v2-stories-carousel-meta {
 /* Arrow controls */
 .v2-stories-carousel-arrowcontrols {
   display: none;
-  margin: 0;
-}
-
-.v2-stories-carousel-arrowcontrols li {
-  align-items: center;
-  display: flex;
-  height: var(--stories-carousel-img-height);
-  left: 10%;
-  position: absolute;
-  top: 0;
-}
-
-.v2-stories-carousel-arrowcontrols li:last-child {
-  left: auto;
-  right: 10%;
-}
-
-.v2-stories-carousel-arrowcontrols button {
-  background-color: var(--c-white);
-  border-radius: 50%;
-  border: 1px solid var(--c-grey-400);
-  color: var(--c-main-black);
-  font-size: 0;
-  line-height: 0;
-  margin: 0;
-  padding: 12px;
-  position: relative;
-  opacity: 0;
-  transition: opacity var(--duration-small) var(--easing-standard);
-}
-
-.v2-stories-carousel-arrowcontrols button:hover {
-  background-color: var(--c-grey-50);
-}
-
-.v2-stories-carousel-arrowcontrols button:active {
-  background-color: var(--c-grey-100);
-}
-
-.v2-stories-carousel-arrowcontrols button:focus {
-  outline: 0;
-}
-
-.v2-stories-carousel-arrowcontrols button:focus-visible {
-  outline: 2px solid var(--border-focus);
-  outline-offset: 1px;
-}
-
-.v2-stories-carousel:hover .v2-stories-carousel-arrowcontrols button,
-.v2-stories-carousel-arrowcontrols button:focus-visible, /* stylelint-disable-line no-descending-specificity */
-.v2-stories-carousel-arrowcontrols:focus-within button {
-  opacity: 1;
 }
 
 @media screen and (min-width: 744px) {


### PR DESCRIPTION
Fix #761

Should restore the arrows below the articles carousel on VT homepage to where they were before the release

